### PR TITLE
Add `protos` to published npm module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "googleapis/nodejs-logging",
   "main": "./src/index.js",
   "files": [
+    "protos",
     "src",
     "AUTHORS",
     "CONTRIBUTORS",


### PR DESCRIPTION
Fixes #14 