### PR TITLE
chore: update-deps: gcp-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "arrify": "^1.0.0",
     "eventid": "^0.1.0",
     "extend": "^3.0.1",
-    "gcp-metadata": "^0.3.1",
+    "gcp-metadata": "^0.4.0",
     "google-auto-auth": "^0.7.1",
     "google-gax": "^0.14.2",
     "google-proto-files": "^0.13.1",


### PR DESCRIPTION
Fixes issue with slow startup when running off of GCP. See: https://github.com/stephenplusplus/gcp-metadata/issues/10.
