### PR TITLE
releasing v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "test": "repo-tools test run --cmd npm -- run cover"
   },
   "dependencies": {
-    "@google-cloud/logging": "1.1.2",
+    "@google-cloud/logging": "1.1.3",
     "@google-cloud/logging-bunyan": "0.6.0",
     "@google-cloud/logging-winston": "0.6.0",
     "@google-cloud/storage": "1.4.0",


### PR DESCRIPTION
Need to release a new version to npm to upgrade dependencies on `@google-cloud/common`. The currently released version requires 0.15.x which is older than we need.