### PR TITLE
Extend system test delay.

### DIFF
--- a/system-test/logging.js
+++ b/system-test/logging.js
@@ -32,7 +32,7 @@ var Logging = require('../');
 describe('Logging', function() {
   var PROJECT_ID;
   var TESTS_PREFIX = 'gcloud-logging-test';
-  var WRITE_CONSISTENCY_DELAY_MS = 3000;
+  var WRITE_CONSISTENCY_DELAY_MS = 10000;
 
   var bigQuery = bigqueryLibrary();
   var pubsub = pubsubLibrary();


### PR DESCRIPTION
Tests are failing randomly. I think this value that sets the delay between a write and a read is too small.