### PR TITLE
fix: Unique-ify getEntries resourceNames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -417,7 +417,12 @@ Logging.prototype.getEntries = function(options, callback) {
   );
 
   reqOpts.resourceNames = arrify(reqOpts.resourceNames);
-  reqOpts.resourceNames.push('projects/' + this.projectId);
+
+  var resourceName = 'projects/' + this.projectId;
+
+  if (reqOpts.resourceNames.indexOf(resourceName) === -1) {
+    reqOpts.resourceNames.push(resourceName);
+  }
 
   delete reqOpts.autoPaginate;
   delete reqOpts.gaxOptions;
@@ -782,6 +787,8 @@ Logging.prototype.request = function(config, callback) {
         callback(err);
         return;
       }
+
+      self.projectId = projectId;
 
       var gaxClient = self.api[config.client];
 

--- a/test/index.js
+++ b/test/index.js
@@ -459,6 +459,21 @@ describe('Logging', function() {
       logging.getEntries(options, assert.ifError);
     });
 
+    it('should not push the same resourceName again', function(done) {
+      var options = {
+        resourceNames: ['projects/' + logging.projectId],
+      };
+
+      logging.request = function(config) {
+        assert.deepEqual(config.reqOpts.resourceNames, [
+          'projects/' + logging.projectId,
+        ]);
+        done();
+      };
+
+      logging.getEntries(options, assert.ifError);
+    });
+
     it('should allow overriding orderBy', function(done) {
       var options = {
         orderBy: 'timestamp asc',
@@ -833,6 +848,17 @@ describe('Logging', function() {
       it('should get the project ID', function(done) {
         logging.auth.getProjectId = function() {
           done();
+        };
+
+        logging.request(CONFIG, assert.ifError);
+      });
+
+      it('should cache the project ID', function(done) {
+        logging.auth.getProjectId = function() {
+          setImmediate(function() {
+            assert.strictEqual(logging.projectId, PROJECT_ID);
+            done();
+          });
         };
 
         logging.request(CONFIG, assert.ifError);


### PR DESCRIPTION
RE: #91 

I caught this while investigating #91. When we auto-paginate using the `nextQuery` object built by GAPIC, we constantly push the project ID resource to the `reqOpts.resourceNames` argument. So for each run, we end up with with a new, duplicate entry of `projects/my-project-id`.

This flattens them, as well as localizes the project ID returned by the auth client, so we can still flatten the array when the user is using ADC.