### PR TITLE
chore(release): bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/logging",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
[release notes](https://github.com/googleapis/nodejs-logging/releases/edit/untagged-717f572534baf338c40c)

This release is needed to fix for https://github.com/googleapis/nodejs-error-reporting/issues/155, which requires a new version of `google-cloud/common` to be picked up. 

Without spinning a release:
```sh
~/src/veneer/nodejs-logging-winston $ npx npm-why @google-cloud/common
npx: installed 10 in 2.22s

  Who required @google-cloud/common:

  @google-cloud/logging-winston > @google-cloud/logging > @google-cloud/common@0.16.2
  @google-cloud/logging-winston > @google-cloud/logging > @google-cloud/common-grpc > @google-cloud/common@0.17.0
```
We need to be able to pick up `common@0.20.2`.

---
This release is semver major release because it drops support for Node 4.x and 9.x. Apart from that there should be no other breaking changes.

# Notable changes
* Node.js 4.x and 9.x are no longer supported (#123)

# Commits
* 876e32d chore(release): bump version to 2.0.0
* f7518e1 Re-generate library using /synth.py (#148)
* dde2613 Re-generate library using /synth.py (#147)
* ae3808c fix(deps): update dependency yargs to v12 (#146)
* 268dab5 Re-generate library using /synth.py (#145)
* bca99ad chore(deps): update dependency uuid to v3.3.0 (#142)
* 19f0d4f chore(deps): update dependency sinon to v6.0.1 (#141)
* f2a5811 Configure Renovate (#129)
* b60f986 Re-generate library using /synth.py (#140)
* a80056a refactor: drop repo-tool as an exec wrapper (#139)
* faa3b6e chore: update sample lockfiles (#138)
* ea534d2 chore(package): update eslint to version 5.0.0 (#134)
* b9e3de4 Re-generate library using /synth.py (#137)
* 4bd42b3 fix: update linking for samples (#136)
* d135381 Re-generate library using /synth.py (#135)
* 01ec04e chore: regenerate the library, upgrade gax
* 654884e Update synth.py, removing generate-scaffolding (#130)
* 7feb300 refactor: update to latest google-auth-library and nodejs-common (#128)
* 267a0fc Create synth script for nodejs-logging (#127)
* 6e26499 fix(package): update @google-cloud/common-grpc to version 0.7.1 (#126)
* c1888d7 refactor: drop dependency on string-format-obj (#124)
* 80862b4 chore: update many dependencies (#122)
* 1ccf7e4 fix: drop support for node 4.x and 9.x (#123)
* 3c4b94c chore(package): update nyc to version 12.0.2 (#117)
* 27f1d04 chore: lock files maintenance (#114)
* 530a155 chore: the ultimate fix for repo-tools EPERM (#113)
* 2a8524f chore: timeout for system test (#112)
* 161711a chore: lock files maintenance (#109)
* 3747e38 chore: test on node10 (#107)
* 807733f chore: lock files maintenance (#106)
* 962fd30 chore: one more workaround for repo-tools EPERM (#103)
* 1151caa chore: workaround for repo-tools EPERM (#101)
* b3bece4 Update @google-cloud/common to the latest version 🚀 (#100)
* cafac75 chore: make samples depend on the current version (#99)
* 6f6eee1 Update google-auto-auth (#98)
* dff5d1b chore: setup nighty build in CircleCI (#97)
