### PR TITLE
fix(gke): include namespace_id in resource

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -35,7 +35,8 @@ function Metadata(logging) {
   this.logging = logging;
 }
 
-Metadata.KUBERNETES_NAMESPACE_ID_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
+Metadata.KUBERNETES_NAMESPACE_ID_PATH =
+  '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
 /**
  * Create a descriptor for Cloud Functions.
@@ -93,7 +94,7 @@ Metadata.getGCEDescriptor = function(callback) {
  * @param {function} callback Callback function.
  * @return {object}
  */
-Metadata.getGKEDescriptor = function (callback) {
+Metadata.getGKEDescriptor = function(callback) {
   // Stackdriver Logging Monitored Resource for 'container' requires
   // cluster_name and namespace_id fields. Note that these *need* to be
   // snake_case. The namespace_id is not easily available from inside the
@@ -101,26 +102,31 @@ Metadata.getGKEDescriptor = function (callback) {
   // namespace_name in place of namespace_id for a while now. Log correlation
   // with metrics may not necessarily work however.
   //
-  gcpMetadata
-    .instance('attributes/cluster-name')
-    .then(function (resp) {
-      fs.readFile(Metadata.KUBERNETES_NAMESPACE_ID_PATH, 'utf8',
-        (err, namespace) => {
-          if (err) {
-            callback(new Error(`Error reading ` +
-              `${Metadata.KUBERNETES_NAMESPACE_ID_PATH}: ${err.message}`));
-            return;
-          }
+  gcpMetadata.instance('attributes/cluster-name').then(function(resp) {
+    fs.readFile(
+      Metadata.KUBERNETES_NAMESPACE_ID_PATH,
+      'utf8',
+      (err, namespace) => {
+        if (err) {
+          callback(
+            new Error(
+              `Error reading ` +
+                `${Metadata.KUBERNETES_NAMESPACE_ID_PATH}: ${err.message}`
+            )
+          );
+          return;
+        }
 
-          callback(null, {
-            type: 'container',
-            labels: {
-              cluster_name: resp.data,
-              namespace_id: namespace
-            },
-          });
+        callback(null, {
+          type: 'container',
+          labels: {
+            cluster_name: resp.data,
+            namespace_id: namespace,
+          },
         });
-    }, callback);
+      }
+    );
+  }, callback);
 };
 
 /**

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+var fs = require('fs');
 var gcpMetadata = require('gcp-metadata');
 
 /**
@@ -33,6 +34,8 @@ var gcpMetadata = require('gcp-metadata');
 function Metadata(logging) {
   this.logging = logging;
 }
+
+Metadata.KUBERNETES_NAMESPACE_ID_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
 /**
  * Create a descriptor for Cloud Functions.
@@ -90,20 +93,34 @@ Metadata.getGCEDescriptor = function(callback) {
  * @param {function} callback Callback function.
  * @return {object}
  */
-Metadata.getGKEDescriptor = function(callback) {
+Metadata.getGKEDescriptor = function (callback) {
+  // Stackdriver Logging Monitored Resource for 'container' requires
+  // cluster_name and namespace_id fields. Note that these *need* to be
+  // snake_case. The namespace_id is not easily available from inside the
+  // container, but we can get the namespace_name. Logging has been using the
+  // namespace_name in place of namespace_id for a while now. Log correlation
+  // with metrics may not necessarily work however.
+  //
   gcpMetadata
     .instance('attributes/cluster-name')
-    .then(function(resp) {
-      callback(null, {
-        type: 'container',
-        labels: {
-          // note(ofrobots): it would be good to include the namespace_id as
-          // well.
-          cluster_name: resp.data,
-        },
-      });
-    })
-    .catch(callback);
+    .then(function (resp) {
+      fs.readFile(Metadata.KUBERNETES_NAMESPACE_ID_PATH, 'utf8',
+        (err, namespace) => {
+          if (err) {
+            callback(new Error(`Error reading ` +
+              `${Metadata.KUBERNETES_NAMESPACE_ID_PATH}: ${err.message}`));
+            return;
+          }
+
+          callback(null, {
+            type: 'container',
+            labels: {
+              cluster_name: resp.data,
+              namespace_id: namespace
+            },
+          });
+        });
+    }, callback);
 };
 
 /**

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -47,13 +47,11 @@ var readFileShouldError;
 var fakeFS = {
   readFile: (filename, encoding, callback) => {
     setImmediate(() => {
-      if (readFileShouldError)
-        callback(new Error(FAKE_READFILE_ERROR_MESSAGE));
-      else
-        callback(null, FAKE_READFILE_CONTENTS);
+      if (readFileShouldError) callback(new Error(FAKE_READFILE_ERROR_MESSAGE));
+      else callback(null, FAKE_READFILE_CONTENTS);
     });
-  }
-}
+  },
+};
 
 describe('metadata', function() {
   var MetadataCached;
@@ -67,7 +65,7 @@ describe('metadata', function() {
   before(function() {
     Metadata = proxyquire('../src/metadata.js', {
       'gcp-metadata': fakeGcpMetadata,
-      'fs': fakeFS
+      fs: fakeFS,
     });
 
     MetadataCached = extend({}, Metadata);
@@ -157,7 +155,7 @@ describe('metadata', function() {
           type: 'container',
           labels: {
             cluster_name: CLUSTER_NAME,
-            namespace_id: FAKE_READFILE_CONTENTS
+            namespace_id: FAKE_READFILE_CONTENTS,
           },
         });
         done();
@@ -321,7 +319,7 @@ describe('metadata', function() {
               type: 'container',
               labels: {
                 cluster_name: CLUSTER_NAME,
-                namespace_id: FAKE_READFILE_CONTENTS
+                namespace_id: FAKE_READFILE_CONTENTS,
               },
             });
             done();

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -41,6 +41,20 @@ var fakeGcpMetadata = {
   },
 };
 
+var FAKE_READFILE_ERROR_MESSAGE = 'fake readFile error';
+var FAKE_READFILE_CONTENTS = 'fake readFile contents';
+var readFileShouldError;
+var fakeFS = {
+  readFile: (filename, encoding, callback) => {
+    setImmediate(() => {
+      if (readFileShouldError)
+        callback(new Error(FAKE_READFILE_ERROR_MESSAGE));
+      else
+        callback(null, FAKE_READFILE_CONTENTS);
+    });
+  }
+}
+
 describe('metadata', function() {
   var MetadataCached;
   var Metadata;
@@ -53,6 +67,7 @@ describe('metadata', function() {
   before(function() {
     Metadata = proxyquire('../src/metadata.js', {
       'gcp-metadata': fakeGcpMetadata,
+      'fs': fakeFS
     });
 
     MetadataCached = extend({}, Metadata);
@@ -65,6 +80,7 @@ describe('metadata', function() {
     extend(Metadata, MetadataCached);
     metadata = new Metadata(LOGGING);
     instanceOverride = null;
+    readFileShouldError = false;
   });
 
   afterEach(function() {
@@ -141,6 +157,7 @@ describe('metadata', function() {
           type: 'container',
           labels: {
             cluster_name: CLUSTER_NAME,
+            namespace_id: FAKE_READFILE_CONTENTS
           },
         });
         done();
@@ -155,6 +172,15 @@ describe('metadata', function() {
 
       Metadata.getGKEDescriptor(function(err) {
         assert.strictEqual(err, FAKE_ERROR);
+        done();
+      });
+    });
+
+    it('should return error when read of namespace file fails', function(done) {
+      readFileShouldError = true;
+      Metadata.getGKEDescriptor(function(err) {
+        assert.ok(err);
+        assert.ok(err.message.includes(FAKE_READFILE_ERROR_MESSAGE));
         done();
       });
     });
@@ -295,6 +321,7 @@ describe('metadata', function() {
               type: 'container',
               labels: {
                 cluster_name: CLUSTER_NAME,
+                namespace_id: FAKE_READFILE_CONTENTS
               },
             });
             done();


### PR DESCRIPTION
Logging requires a namespace_id field for the GKE 'container' monitored
resource descriptor. namespace_id is not easily available, but the
namespace_name works, and is the current recommended workaround by the
Logging team.

Fixes: https://github.com/googleapis/nodejs-logging-bunyan/issues/123
