### PR TITLE
fix(gke): correctly detect kubernetes engine

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -149,7 +149,7 @@ Metadata.prototype.getDefaultResource = function(callback) {
   this.logging.auth
     .getEnv()
     .then(env => {
-      if (env === 'CONTAINER_ENGINE') {
+      if (env === 'KUBERNETES_ENGINE') {
         Metadata.getGKEDescriptor(callback);
       } else if (env === 'APP_ENGINE') {
         callback(null, Metadata.getGAEDescriptor());

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -310,7 +310,7 @@ describe('metadata', function() {
           };
 
           metadata.logging.auth.getEnv = function() {
-            return Promise.resolve('CONTAINER_ENGINE');
+            return Promise.resolve('KUBERNETES_ENGINE');
           };
 
           metadata.getDefaultResource(function(err, defaultResource) {


### PR DESCRIPTION
The value actually returned by google-auth-library is [`KUBERNETES_ENGINE`](https://github.com/google/google-auth-library-nodejs/blob/bad432105f5ad0203266e9c6b31d2235fc96534b/src/auth/envDetect.ts#L21).

This regressed in https://github.com/googleapis/nodejs-logging/pull/128.
