### PR TITLE
Release nodejs-logging v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://www.npmjs.com/package/nodejs-logging?activeTab=versions
 
+## v3.0.2
+
+This release includes a few minor internal changes.
+
+### Internal / Testing Changes
+- chore: upgrade to the latest common-grpc (#203)
+- Re-generate library using /synth.py (#202)
+- chore(deps): update dependency nyc to v13 (#200)
+- chore(deps): update samples dependency @google-cloud/logging-bunyan to ^0.9.0 (#199)
+- fix(deps): update dependency google-gax to ^0.19.0 (#198)
+- chore: use mocha for sample tests (#197)
+
 ## v3.0.0
 
 **This release has breaking changes**.  Support for Node.js 4.x and 9.x has been dropped for this release.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
This pull request was generated using releasetool.