### PR TITLE
Use es classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ```javascript
 // Imports the Google Cloud client library
-const Logging = require('@google-cloud/logging');
+const {Logging} = require('@google-cloud/logging');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   "devDependencies": {
     "@google-cloud/bigquery": "*",
     "@google-cloud/nodejs-repo-tools": "^2.3.3",
-    "@google-cloud/pubsub": "*",
-    "@google-cloud/storage": "*",
+    "@google-cloud/pubsub": "0.20.0",
+    "@google-cloud/storage": "^2.0.2",
     "async": "^2.6.1",
     "codecov": "^3.0.4",
     "eslint": "^5.4.0",

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -18,7 +18,7 @@
 function writeLogEntry(logName) {
   // [START logging_write_log_entry]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -66,7 +66,7 @@ function writeLogEntry(logName) {
 function writeLogEntryAdvanced(logName, options) {
   // [START logging_write_log_entry_advanced]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -100,7 +100,7 @@ function writeLogEntryAdvanced(logName, options) {
 function listLogEntries(logName) {
   // [START logging_list_log_entries]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -134,7 +134,7 @@ function listLogEntries(logName) {
 function listLogEntriesAdvanced(filter, pageSize, orderBy) {
   // [START logging_list_log_entries_advanced]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -176,7 +176,7 @@ function listLogEntriesAdvanced(filter, pageSize, orderBy) {
 function deleteLog(logName) {
   // [START logging_delete_log]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "@google-cloud/logging": "^3.0.0",
     "@google-cloud/logging-bunyan": "^0.9.0",
     "@google-cloud/logging-winston": "^0.9.0",
-    "@google-cloud/storage": "^2.0.0",
+    "@google-cloud/storage": "^2.0.2",
     "bunyan": "^1.8.12",
     "express": "^4.16.3",
     "fluent-logger": "^3.0.0",

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START logging_quickstart]
 // Imports the Google Cloud client library
-const Logging = require('@google-cloud/logging');
+const {Logging} = require('@google-cloud/logging');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/sinks.js
+++ b/samples/sinks.js
@@ -18,8 +18,8 @@
 function createSink(sinkName, bucketName, filter) {
   // [START logging_create_sink]
   // Imports the Google Cloud client libraries
-  const Logging = require('@google-cloud/logging');
-  const Storage = require('@google-cloud/storage');
+  const {Logging} = require('@google-cloud/logging');
+  const {Storage} = require('@google-cloud/storage');
 
   // Creates clients
   const logging = new Logging();
@@ -66,7 +66,7 @@ function createSink(sinkName, bucketName, filter) {
 function getSinkMetadata(sinkName) {
   // [START logging_get_sink]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -97,7 +97,7 @@ function getSinkMetadata(sinkName) {
 function listSinks() {
   // [START logging_list_sinks]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -124,7 +124,7 @@ function listSinks() {
 function updateSink(sinkName, filter) {
   // [START logging_update_sink]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();
@@ -164,7 +164,7 @@ function updateSink(sinkName, filter) {
 function deleteSink(sinkName) {
   // [START logging_delete_sink]
   // Imports the Google Cloud client library
-  const Logging = require('@google-cloud/logging');
+  const {Logging} = require('@google-cloud/logging');
 
   // Creates a client
   const logging = new Logging();

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -21,7 +21,8 @@ const assert = require('assert');
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const uuid = require(`uuid`);
 
-const logging = proxyquire(`@google-cloud/logging`, {})();
+const {Logging} = proxyquire(`@google-cloud/logging`, {});
+const logging = new Logging();
 
 const logName = `nodejs-docs-samples-test-${uuid.v4()}`;
 
@@ -70,6 +71,8 @@ it(`should log an entry`, done => {
     },
   };
   proxyquire(`../quickstart`, {
-    '@google-cloud/logging': sinon.stub().returns(loggingMock),
+    '@google-cloud/logging': {
+      Logging: sinon.stub().returns(loggingMock),
+    },
   });
 });

--- a/samples/system-test/sinks.test.js
+++ b/samples/system-test/sinks.test.js
@@ -15,9 +15,9 @@
 
 'use strict';
 
-const logging = new (require('@google-cloud/logging'))();
+const {Logging} = new require('@google-cloud/logging');
 const path = require(`path`);
-const storage = new (require('@google-cloud/storage'))();
+const {Storage} = new require('@google-cloud/storage');
 const assert = require('assert');
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const uuid = require(`uuid`);
@@ -29,6 +29,8 @@ const cmd = `node sinks.js`;
 const bucketName = `nodejs-logging-sinks-test-${uuid.v4()}`;
 const sinkName = `nodejs-logging-sinks-test-${uuid.v4()}`;
 const filter = `severity > WARNING`;
+const logging = new Logging();
+const storage = new Storage();
 
 before(tools.checkCredentials);
 before(async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -109,9 +109,6 @@ const {Sink} = require('./sink');
  */
 class Logging {
   constructor(options) {
-    if (!(this instanceof Logging)) {
-      return new Logging(options);
-    }
     // Determine what scopes are needed.
     // It is the union of the scopes on all three clients.
     let scopes = [];

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,9 @@ const through = require('through2');
 const PKG = require('../package.json');
 const v2 = require('./v2');
 
-const Entry = require('./entry.js');
-const Log = require('./log.js');
-const Sink = require('./sink.js');
+const {Entry} = require('./entry');
+const {Log} = require('./log');
+const {Sink} = require('./sink');
 
 /**
  * @namespace google
@@ -53,7 +53,6 @@ const Sink = require('./sink.js');
 /**
  * @namespace google.protobuf
  */
-
 /**
  * @typedef {object} ClientConfig
  * @property {string} [projectId] The project ID from the Google Developer's
@@ -78,7 +77,6 @@ const Sink = require('./sink.js');
  * @property {Constructor} [promise] Custom promise module to use instead of
  *     native Promises.
  */
-
 /**
  * [Stackdriver Logging](https://cloud.google.com/logging/docs) allows you to
  * store, search, analyze, monitor, and alert on log data and events from Google
@@ -94,7 +92,7 @@ const Sink = require('./sink.js');
  * @param {ClientConfig} [options] Configuration options.
  *
  * @example <caption>Import the client library</caption>
- * const Logging = require('@google-cloud/logging');
+ * const {Logging} = require('@google-cloud/logging');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const logging = new Logging();
@@ -109,400 +107,292 @@ const Sink = require('./sink.js');
  * region_tag:logging_quickstart
  * Full quickstart example:
  */
-function Logging(options) {
-  if (!(this instanceof Logging)) {
-    return new Logging(options);
-  }
-
-  // Determine what scopes are needed.
-  // It is the union of the scopes on all three clients.
-  let scopes = [];
-  let clientClasses = [
-    v2.ConfigServiceV2Client,
-    v2.LoggingServiceV2Client,
-    v2.MetricsServiceV2Client,
-  ];
-  for (let clientClass of clientClasses) {
-    for (let scope of clientClass.scopes) {
-      if (clientClasses.indexOf(scope) === -1) {
-        scopes.push(scope);
+class Logging {
+  constructor(options) {
+    if (!(this instanceof Logging)) {
+      return new Logging(options);
+    }
+    // Determine what scopes are needed.
+    // It is the union of the scopes on all three clients.
+    let scopes = [];
+    let clientClasses = [
+      v2.ConfigServiceV2Client,
+      v2.LoggingServiceV2Client,
+      v2.MetricsServiceV2Client,
+    ];
+    for (let clientClass of clientClasses) {
+      for (let scope of clientClass.scopes) {
+        if (clientClasses.indexOf(scope) === -1) {
+          scopes.push(scope);
+        }
       }
     }
+    const options_ = extend(
+      {
+        libName: 'gccl',
+        libVersion: PKG.version,
+        scopes: scopes,
+      },
+      options
+    );
+    this.api = {};
+    this.auth = new GoogleAuth(options_);
+    this.options = options_;
+    this.projectId = this.options.projectId || '{{projectId}}';
   }
-
-  const options_ = extend(
-    {
-      libName: 'gccl',
-      libVersion: PKG.version,
-      scopes: scopes,
-    },
-    options
-  );
-
-  this.api = {};
-  this.auth = new GoogleAuth(options_);
-  this.options = options_;
-  this.projectId = this.options.projectId || '{{projectId}}';
-}
-
-/**
- * Config to set for the sink. Not all available options are listed here, see
- * the [Sink resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink)
- * definition for full details.
- *
- * @typedef {object} CreateSinkRequest
- * @property {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @property {Bucket|Dataset|Topic} [destination] The destination. The proper ACL
- *     scopes will be granted to the provided destination. Can be one of:
- *     {@link https://cloud.google.com/nodejs/docs/reference/storage/latest/Bucket Bucket},
- *     {@link https://cloud.google.com/nodejs/docs/reference/bigquery/latest/Dataset Dataset},
- *     or {@link https://cloud.google.com/nodejs/docs/reference/pubsub/latest/Topic Topic}
- * @property {string} [filter] An advanced logs filter. Only log entries
- *     matching the filter are written.
- */
-/**
- * @typedef {array} CreateSinkResponse
- * @property {Sink} 0 The new {@link Sink}.
- * @property {object} 1 The full API response.
- */
-/**
- * @callback CreateSinkCallback
- * @param {?Error} err Request error, if any.
- * @param {Sink} sink The new {@link Sink}.
- * @param {object} apiResponse The full API response.
- */
-// jscs:disable maximumLineLength
-/**
- * Create a sink.
- *
- * @see [Sink Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks}
- * @see [Advanced Logs Filters]{@link https://cloud.google.com/logging/docs/view/advanced_filters}
- * @see [projects.sinks.create API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/create}
- *
- * @param {string} name Name of the sink.
- * @param {CreateSinkRequest} config Config to set for the sink.
- * @param {CreateSinkCallback} [callback] Callback function.
- * @returns {Promise<CreateSinkResponse>}
- * @throws {Error} If a name is not provided.
- * @throws {Error} if a config object is not provided.
- * @see Sink#create
- *
- * @example
- * const Storage = require('@google-cloud/storage');
- * const storage = new Storage({
- *   projectId: 'grape-spaceship-123'
- * });
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * const config = {
- *   destination: storage.bucket('logging-bucket'),
- *   filter: 'severity = ALERT'
- * };
- *
- * function callback(err, sink, apiResponse) {
- *   // `sink` is a Sink object.
- * }
- *
- * logging.createSink('new-sink-name', config, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * logging.createSink('new-sink-name', config).then(function(data) {
- *   const sink = data[0];
- *   const apiResponse = data[1];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_create_sink
- * Another example:
- */
-Logging.prototype.createSink = function(name, config, callback) {
-  // jscs:enable maximumLineLength
-  const self = this;
-
-  if (!is.string(name)) {
-    throw new Error('A sink name must be provided.');
-  }
-
-  if (!is.object(config)) {
-    throw new Error('A sink configuration object must be provided.');
-  }
-
-  if (common.util.isCustomType(config.destination, 'bigquery/dataset')) {
-    this.setAclForDataset_(name, config, callback);
-    return;
-  }
-
-  if (common.util.isCustomType(config.destination, 'pubsub/topic')) {
-    this.setAclForTopic_(name, config, callback);
-    return;
-  }
-
-  if (common.util.isCustomType(config.destination, 'storage/bucket')) {
-    this.setAclForBucket_(name, config, callback);
-    return;
-  }
-
-  const reqOpts = {
-    parent: 'projects/' + this.projectId,
-    sink: extend({}, config, {name: name}),
-  };
-
-  delete reqOpts.sink.gaxOptions;
-
-  this.request(
-    {
-      client: 'ConfigServiceV2Client',
-      method: 'createSink',
-      reqOpts: reqOpts,
-      gaxOpts: config.gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
+  /**
+   * Config to set for the sink. Not all available options are listed here, see
+   * the [Sink resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink)
+   * definition for full details.
+   *
+   * @typedef {object} CreateSinkRequest
+   * @property {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {Bucket|Dataset|Topic} [destination] The destination. The proper ACL
+   *     scopes will be granted to the provided destination. Can be one of:
+   *     {@link https://cloud.google.com/nodejs/docs/reference/storage/latest/Bucket Bucket},
+   *     {@link https://cloud.google.com/nodejs/docs/reference/bigquery/latest/Dataset Dataset},
+   *     or {@link https://cloud.google.com/nodejs/docs/reference/pubsub/latest/Topic Topic}
+   * @property {string} [filter] An advanced logs filter. Only log entries
+   *     matching the filter are written.
+   */
+  /**
+   * @typedef {array} CreateSinkResponse
+   * @property {Sink} 0 The new {@link Sink}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback CreateSinkCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Sink} sink The new {@link Sink}.
+   * @param {object} apiResponse The full API response.
+   */
+  // jscs:disable maximumLineLength
+  /**
+   * Create a sink.
+   *
+   * @see [Sink Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks}
+   * @see [Advanced Logs Filters]{@link https://cloud.google.com/logging/docs/view/advanced_filters}
+   * @see [projects.sinks.create API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/create}
+   *
+   * @param {string} name Name of the sink.
+   * @param {CreateSinkRequest} config Config to set for the sink.
+   * @param {CreateSinkCallback} [callback] Callback function.
+   * @returns {Promise<CreateSinkResponse>}
+   * @throws {Error} If a name is not provided.
+   * @throws {Error} if a config object is not provided.
+   * @see Sink#create
+   *
+   * @example
+   * const {Storage} = require('@google-cloud/storage');
+   * const storage = new Storage({
+   *   projectId: 'grape-spaceship-123'
+   * });
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * const config = {
+   *   destination: storage.bucket('logging-bucket'),
+   *   filter: 'severity = ALERT'
+   * };
+   *
+   * function callback(err, sink, apiResponse) {
+   *   // `sink` is a Sink object.
+   * }
+   *
+   * logging.createSink('new-sink-name', config, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * logging.createSink('new-sink-name', config).then(function(data) {
+   *   const sink = data[0];
+   *   const apiResponse = data[1];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_create_sink
+   * Another example:
+   */
+  createSink(name, config, callback) {
+    // jscs:enable maximumLineLength
+    const self = this;
+    if (!is.string(name)) {
+      throw new Error('A sink name must be provided.');
+    }
+    if (!is.object(config)) {
+      throw new Error('A sink configuration object must be provided.');
+    }
+    if (common.util.isCustomType(config.destination, 'bigquery/dataset')) {
+      this.setAclForDataset_(name, config, callback);
+      return;
+    }
+    if (common.util.isCustomType(config.destination, 'pubsub/topic')) {
+      this.setAclForTopic_(name, config, callback);
+      return;
+    }
+    if (common.util.isCustomType(config.destination, 'storage/bucket')) {
+      this.setAclForBucket_(name, config, callback);
+      return;
+    }
+    const reqOpts = {
+      parent: 'projects/' + this.projectId,
+      sink: extend({}, config, {name: name}),
+    };
+    delete reqOpts.sink.gaxOptions;
+    this.request(
+      {
+        client: 'ConfigServiceV2Client',
+        method: 'createSink',
+        reqOpts: reqOpts,
+        gaxOpts: config.gaxOptions,
+      },
+      function(err, resp) {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+        const sink = self.sink(resp.name);
+        sink.metadata = resp;
+        callback(null, sink, resp);
       }
-
-      const sink = self.sink(resp.name);
-      sink.metadata = resp;
-
-      callback(null, sink, resp);
-    }
-  );
-};
-
-/**
- * Create an entry object.
- *
- * Note that using this method will not itself make any API requests. You will
- * use the object returned in other API calls, such as
- * {@link Log#write}.
- *
- * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
- *
- * @param {?object|?string} [resource] See a
- *     [Monitored Resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource).
- * @param {object|string} data The data to use as the value for this log
- *     entry.
- * @returns {Entry}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * const resource = {
- *   type: 'gce_instance',
- *   labels: {
- *     zone: 'global',
- *     instance_id: '3'
- *   }
- * };
- *
- * const entry = logging.entry(resource, {
- *   delegate: 'my_username'
- * });
- *
- * entry.toJSON();
- * // {
- * //   resource: {
- * //     type: 'gce_instance',
- * //     labels: {
- * //       zone: 'global',
- * //       instance_id: '3'
- * //     }
- * //   },
- * //   jsonPayload: {
- * //     delegate: 'my_username'
- * //   }
- * // }
- */
-Logging.prototype.entry = function(resource, data) {
-  return new Entry(resource, data);
-};
-
-/**
- * Query object for listing entries.
- *
- * @typedef {object} GetEntriesRequest
- * @property {boolean} [autoPaginate=true] Have pagination handled
- *     automatically.
- * @property {string} [filter] An
- *     [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters).
- *     An empty filter matches all log entries.
- * @property {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @property {number} [maxApiCalls] Maximum number of API calls to make.
- * @property {number} [maxResults] Maximum number of items plus prefixes to
- *     return.
- * @property {string} [orderBy] How the results should be sorted,
- *     `timestamp` (oldest first) and `timestamp desc` (newest first,
- *     **default**).
- * @property {number} [pageSize] Maximum number of logs to return.
- * @property {string} [pageToken] A previously-returned page token
- *     representing part of the larger set of results to view.
- */
-/**
- * @typedef {array} GetEntriesResponse
- * @property {Entry[]} 0 Array of {@link Entry} instances.
- * @property {object} 1 The full API response.
- */
-/**
- * @callback GetEntriesCallback
- * @param {?Error} err Request error, if any.
- * @param {Entry[]} entries Array of {@link Entry} instances.
- * @param {object} apiResponse The full API response.
- */
-/**
- * List the entries in your logs.
- *
- * @see [entries.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list}
- *
- * @param {GetEntriesRequest} [query] Query object for listing entries.
- * @param {GetEntriesCallback} [callback] Callback function.
- * @returns {Promise<GetEntriesResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * logging.getEntries(function(err, entries) {
- *   // `entries` is an array of Stackdriver Logging entry objects.
- *   // See the `data` property to read the data from the entry.
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to `false`.
- * //-
- * function callback(err, entries, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     logging.getEntries(nextQuery, callback);
- *   }
- * }
- *
- * logging.getEntries({
- *   autoPaginate: false
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * logging.getEntries().then(function(data) {
- *   const entries = data[0];
- * });
- *
- * @example <caption>include:samples/logs.js</caption>
- * region_tag:logging_list_log_entries
- * Another example:
- *
- * @example <caption>include:samples/logs.js</caption>
- * region_tag:logging_list_log_entries_advanced
- * Another example:
- */
-Logging.prototype.getEntries = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
+    );
   }
 
-  const reqOpts = extend(
-    {
-      orderBy: 'timestamp desc',
-    },
-    options
-  );
-
-  reqOpts.resourceNames = arrify(reqOpts.resourceNames);
-
-  const resourceName = 'projects/' + this.projectId;
-
-  if (reqOpts.resourceNames.indexOf(resourceName) === -1) {
-    reqOpts.resourceNames.push(resourceName);
+  /**
+   * Create an entry object.
+   *
+   * Note that using this method will not itself make any API requests. You will
+   * use the object returned in other API calls, such as
+   * {@link Log#write}.
+   *
+   * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
+   *
+   * @param {?object|?string} [resource] See a
+   *     [Monitored Resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource).
+   * @param {object|string} data The data to use as the value for this log
+   *     entry.
+   * @returns {Entry}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * const resource = {
+   *   type: 'gce_instance',
+   *   labels: {
+   *     zone: 'global',
+   *     instance_id: '3'
+   *   }
+   * };
+   *
+   * const entry = logging.entry(resource, {
+   *   delegate: 'my_username'
+   * });
+   *
+   * entry.toJSON();
+   * // {
+   * //   resource: {
+   * //     type: 'gce_instance',
+   * //     labels: {
+   * //       zone: 'global',
+   * //       instance_id: '3'
+   * //     }
+   * //   },
+   * //   jsonPayload: {
+   * //     delegate: 'my_username'
+   * //   }
+   * // }
+   */
+  entry(resource, data) {
+    return new Entry(resource, data);
   }
 
-  delete reqOpts.autoPaginate;
-  delete reqOpts.gaxOptions;
-
-  const gaxOptions = extend(
-    {
-      autoPaginate: options.autoPaginate,
-    },
-    options.gaxOptions
-  );
-
-  this.request(
-    {
-      client: 'LoggingServiceV2Client',
-      method: 'listLogEntries',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      const entries = arguments[1];
-
-      if (entries) {
-        arguments[1] = entries.map(Entry.fromApiResponse_);
-      }
-
-      callback.apply(null, arguments);
+  /**
+   * Query object for listing entries.
+   *
+   * @typedef {object} GetEntriesRequest
+   * @property {boolean} [autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @property {string} [filter] An
+   *     [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters).
+   *     An empty filter matches all log entries.
+   * @property {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {number} [maxApiCalls] Maximum number of API calls to make.
+   * @property {number} [maxResults] Maximum number of items plus prefixes to
+   *     return.
+   * @property {string} [orderBy] How the results should be sorted,
+   *     `timestamp` (oldest first) and `timestamp desc` (newest first,
+   *     **default**).
+   * @property {number} [pageSize] Maximum number of logs to return.
+   * @property {string} [pageToken] A previously-returned page token
+   *     representing part of the larger set of results to view.
+   */
+  /**
+   * @typedef {array} GetEntriesResponse
+   * @property {Entry[]} 0 Array of {@link Entry} instances.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetEntriesCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Entry[]} entries Array of {@link Entry} instances.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * List the entries in your logs.
+   *
+   * @see [entries.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list}
+   *
+   * @param {GetEntriesRequest} [query] Query object for listing entries.
+   * @param {GetEntriesCallback} [callback] Callback function.
+   * @returns {Promise<GetEntriesResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * logging.getEntries(function(err, entries) {
+   *   // `entries` is an array of Stackdriver Logging entry objects.
+   *   // See the `data` property to read the data from the entry.
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to `false`.
+   * //-
+   * function callback(err, entries, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     logging.getEntries(nextQuery, callback);
+   *   }
+   * }
+   *
+   * logging.getEntries({
+   *   autoPaginate: false
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * logging.getEntries().then(function(data) {
+   *   const entries = data[0];
+   * });
+   *
+   * @example <caption>include:samples/logs.js</caption>
+   * region_tag:logging_list_log_entries
+   * Another example:
+   *
+   * @example <caption>include:samples/logs.js</caption>
+   * region_tag:logging_list_log_entries_advanced
+   * Another example:
+   */
+  getEntries(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
     }
-  );
-};
-
-/**
- * List the {@link Entry} objects in your logs as a readable object
- * stream.
- *
- * @method Logging#getEntriesStream
- * @param {GetEntriesRequest} [query] Query object for listing entries.
- * @returns {ReadableStream} A readable stream that emits {@link Entry}
- *     instances.
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * logging.getEntriesStream()
- *   .on('error', console.error)
- *   .on('data', function(entry) {
- *     // `entry` is a Stackdriver Logging entry object.
- *     // See the `data` property to read the data from the entry.
- *   })
- *   .on('end', function() {
- *     // All entries retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * logging.getEntriesStream()
- *   .on('data', function(entry) {
- *     this.end();
- *   });
- */
-Logging.prototype.getEntriesStream = function(options) {
-  const self = this;
-  options = options || {};
-
-  let requestStream;
-  const userStream = streamEvents(pumpify.obj());
-
-  userStream.abort = function() {
-    if (requestStream) {
-      requestStream.abort();
-    }
-  };
-
-  const toEntryStream = through.obj(function(entry, _, next) {
-    next(null, Entry.fromApiResponse_(entry));
-  });
-
-  userStream.once('reading', function() {
     const reqOpts = extend(
       {
         orderBy: 'timestamp desc',
@@ -510,452 +400,480 @@ Logging.prototype.getEntriesStream = function(options) {
       options
     );
     reqOpts.resourceNames = arrify(reqOpts.resourceNames);
-    reqOpts.resourceNames.push('projects/' + self.projectId);
-
+    const resourceName = 'projects/' + this.projectId;
+    if (reqOpts.resourceNames.indexOf(resourceName) === -1) {
+      reqOpts.resourceNames.push(resourceName);
+    }
     delete reqOpts.autoPaginate;
     delete reqOpts.gaxOptions;
-
     const gaxOptions = extend(
       {
         autoPaginate: options.autoPaginate,
       },
       options.gaxOptions
     );
-
-    requestStream = self.request({
-      client: 'LoggingServiceV2Client',
-      method: 'listLogEntriesStream',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    });
-
-    userStream.setPipeline(requestStream, toEntryStream);
-  });
-
-  return userStream;
-};
-
-/**
- * Query object for listing sinks.
- *
- * @typedef {object} GetSinksRequest
- * @property {boolean} [autoPaginate=true] Have pagination handled
- *     automatically.
- * @property {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @property {number} [maxApiCalls] Maximum number of API calls to make.
- * @property {number} [maxResults] Maximum number of items plus prefixes to
- *     return.
- * @property {number} [pageSize] Maximum number of logs to return.
- * @property {string} [pageToken] A previously-returned page token
- *     representing part of the larger set of results to view.
- */
-/**
- * @typedef {array} GetSinksResponse
- * @property {Sink[]} 0 Array of {@link Sink} instances.
- * @property {object} 1 The full API response.
- */
-/**
- * @callback GetSinksCallback
- * @param {?Error} err Request error, if any.
- * @param {Sink[]} sinks Array of {@link Sink} instances.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Get the sinks associated with this project.
- *
- * @see [projects.sinks.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/list}
- *
- * @param {GetSinksRequest} [query] Query object for listing sinks.
- * @param {GetSinksCallback} [callback] Callback function.
- * @returns {Promise<GetSinksResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * logging.getSinks(function(err, sinks) {
- *   // sinks is an array of Sink objects.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * logging.getSinks().then(function(data) {
- *   const sinks = data[0];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_list_sinks
- * Another example:
- */
-Logging.prototype.getSinks = function(options, callback) {
-  const self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
+    this.request(
+      {
+        client: 'LoggingServiceV2Client',
+        method: 'listLogEntries',
+        reqOpts: reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      function() {
+        const entries = arguments[1];
+        if (entries) {
+          arguments[1] = entries.map(Entry.fromApiResponse_);
+        }
+        callback.apply(null, arguments);
+      }
+    );
   }
 
-  const reqOpts = extend({}, options, {
-    parent: 'projects/' + this.projectId,
-  });
-
-  delete reqOpts.autoPaginate;
-  delete reqOpts.gaxOptions;
-
-  const gaxOptions = extend(
-    {
-      autoPaginate: options.autoPaginate,
-    },
-    options.gaxOptions
-  );
-
-  this.request(
-    {
-      client: 'ConfigServiceV2Client',
-      method: 'listSinks',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      const sinks = arguments[1];
-
-      if (sinks) {
-        arguments[1] = sinks.map(function(sink) {
-          const sinkInstance = self.sink(sink.name);
-          sinkInstance.metadata = sink;
-          return sinkInstance;
-        });
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
-};
-
-/**
- * Get the {@link Sink} objects associated with this project as a
- * readable object stream.
- *
- * @method Logging#getSinksStream
- * @param {GetSinksRequest} [query] Query object for listing sinks.
- * @returns {ReadableStream} A readable stream that emits {@link Sink}
- *     instances.
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- *
- * logging.getSinksStream()
- *   .on('error', console.error)
- *   .on('data', function(sink) {
- *     // `sink` is a Sink object.
- *   })
- *   .on('end', function() {
- *     // All sinks retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * logging.getSinksStream()
- *   .on('data', function(sink) {
- *     this.end();
- *   });
- */
-Logging.prototype.getSinksStream = function(options) {
-  const self = this;
-
-  options = options || {};
-
-  let requestStream;
-  const userStream = streamEvents(pumpify.obj());
-
-  userStream.abort = function() {
-    if (requestStream) {
-      requestStream.abort();
-    }
-  };
-
-  const toSinkStream = through.obj(function(sink, _, next) {
-    const sinkInstance = self.sink(sink.name);
-    sinkInstance.metadata = sink;
-    next(null, sinkInstance);
-  });
-
-  userStream.once('reading', function() {
-    const reqOpts = extend({}, options, {
-      parent: 'projects/' + self.projectId,
-    });
-
-    delete reqOpts.gaxOptions;
-
-    const gaxOptions = extend(
-      {
-        autoPaginate: options.autoPaginate,
-      },
-      options.gaxOptions
-    );
-
-    requestStream = self.request({
-      client: 'ConfigServiceV2Client',
-      method: 'listSinksStream',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    });
-
-    userStream.setPipeline(requestStream, toSinkStream);
-  });
-
-  return userStream;
-};
-
-/**
- * Get a reference to a Stackdriver Logging log.
- *
- * @see [Log Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs}
- *
- * @param {string} name Name of the existing log.
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.removeCircular] Replace circular references in
- *     logged objects with a string value, `[Circular]`. (Default: false)
- * @returns {Log}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- */
-Logging.prototype.log = function(name, options) {
-  return new Log(this, name, options);
-};
-
-/**
- * Get a reference to a Stackdriver Logging sink.
- *
- * @see [Sink Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks}
- *
- * @param {string} name Name of the existing sink.
- * @returns {Sink}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- */
-Logging.prototype.sink = function(name) {
-  return new Sink(this, name);
-};
-
-/**
- * Funnel all API requests through this method, to be sure we have a project ID.
- *
- * @param {object} config Configuration object.
- * @param {object} config.gaxOpts GAX options.
- * @param {function} config.method The gax method to call.
- * @param {object} config.reqOpts Request options.
- * @param {function} [callback] Callback function.
- */
-Logging.prototype.request = function(config, callback) {
-  const self = this;
-  const isStreamMode = !callback;
-
-  let gaxStream;
-  let stream;
-
-  if (isStreamMode) {
-    stream = streamEvents(through.obj());
-
-    stream.abort = function() {
-      if (gaxStream && gaxStream.cancel) {
-        gaxStream.cancel();
+  /**
+   * List the {@link Entry} objects in your logs as a readable object
+   * stream.
+   *
+   * @method Logging#getEntriesStream
+   * @param {GetEntriesRequest} [query] Query object for listing entries.
+   * @returns {ReadableStream} A readable stream that emits {@link Entry}
+   *     instances.
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * logging.getEntriesStream()
+   *   .on('error', console.error)
+   *   .on('data', function(entry) {
+   *     // `entry` is a Stackdriver Logging entry object.
+   *     // See the `data` property to read the data from the entry.
+   *   })
+   *   .on('end', function() {
+   *     // All entries retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * logging.getEntriesStream()
+   *   .on('data', function(entry) {
+   *     this.end();
+   *   });
+   */
+  getEntriesStream(options) {
+    const self = this;
+    options = options || {};
+    let requestStream;
+    const userStream = streamEvents(pumpify.obj());
+    userStream.abort = function() {
+      if (requestStream) {
+        requestStream.abort();
       }
     };
-
-    stream.once('reading', makeRequestStream);
-  } else {
-    makeRequestCallback();
-  }
-
-  function prepareGaxRequest(callback) {
-    self.auth.getProjectId(function(err, projectId) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      self.projectId = projectId;
-
-      let gaxClient = self.api[config.client];
-
-      if (!gaxClient) {
-        // Lazily instantiate client.
-        gaxClient = new v2[config.client](self.options);
-        self.api[config.client] = gaxClient;
-      }
-
-      let reqOpts = extend(true, {}, config.reqOpts);
-      reqOpts = replaceProjectIdToken(reqOpts, projectId);
-
-      const requestFn = gaxClient[config.method].bind(
-        gaxClient,
-        reqOpts,
-        config.gaxOpts
+    const toEntryStream = through.obj(function(entry, _, next) {
+      next(null, Entry.fromApiResponse_(entry));
+    });
+    userStream.once('reading', function() {
+      const reqOpts = extend(
+        {
+          orderBy: 'timestamp desc',
+        },
+        options
       );
-
-      callback(null, requestFn);
+      reqOpts.resourceNames = arrify(reqOpts.resourceNames);
+      reqOpts.resourceNames.push('projects/' + self.projectId);
+      delete reqOpts.autoPaginate;
+      delete reqOpts.gaxOptions;
+      const gaxOptions = extend(
+        {
+          autoPaginate: options.autoPaginate,
+        },
+        options.gaxOptions
+      );
+      requestStream = self.request({
+        client: 'LoggingServiceV2Client',
+        method: 'listLogEntriesStream',
+        reqOpts: reqOpts,
+        gaxOpts: gaxOptions,
+      });
+      userStream.setPipeline(requestStream, toEntryStream);
     });
+    return userStream;
   }
-
-  function makeRequestCallback() {
-    if (global.GCLOUD_SANDBOX_ENV) {
-      return;
+  /**
+   * Query object for listing sinks.
+   *
+   * @typedef {object} GetSinksRequest
+   * @property {boolean} [autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @property {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {number} [maxApiCalls] Maximum number of API calls to make.
+   * @property {number} [maxResults] Maximum number of items plus prefixes to
+   *     return.
+   * @property {number} [pageSize] Maximum number of logs to return.
+   * @property {string} [pageToken] A previously-returned page token
+   *     representing part of the larger set of results to view.
+   */
+  /**
+   * @typedef {array} GetSinksResponse
+   * @property {Sink[]} 0 Array of {@link Sink} instances.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetSinksCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Sink[]} sinks Array of {@link Sink} instances.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Get the sinks associated with this project.
+   *
+   * @see [projects.sinks.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/list}
+   *
+   * @param {GetSinksRequest} [query] Query object for listing sinks.
+   * @param {GetSinksCallback} [callback] Callback function.
+   * @returns {Promise<GetSinksResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * logging.getSinks(function(err, sinks) {
+   *   // sinks is an array of Sink objects.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * logging.getSinks().then(function(data) {
+   *   const sinks = data[0];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_list_sinks
+   * Another example:
+   */
+  getSinks(options, callback) {
+    const self = this;
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
     }
-
-    prepareGaxRequest(function(err, requestFn) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      requestFn(callback);
+    const reqOpts = extend({}, options, {
+      parent: 'projects/' + this.projectId,
     });
-  }
-
-  function makeRequestStream() {
-    if (global.GCLOUD_SANDBOX_ENV) {
-      return through.obj();
-    }
-
-    prepareGaxRequest(function(err, requestFn) {
-      if (err) {
-        stream.destroy(err);
-        return;
-      }
-
-      gaxStream = requestFn();
-
-      gaxStream
-        .on('error', function(err) {
-          stream.destroy(err);
-        })
-        .pipe(stream);
-    });
-  }
-
-  return stream;
-};
-
-/**
- * This method is called when creating a sink with a Bucket destination. The
- * bucket must first grant proper ACL access to the Stackdriver Logging account.
- *
- * The parameters are the same as what {@link Logging#createSink} accepts.
- *
- * @private
- */
-Logging.prototype.setAclForBucket_ = function(name, config, callback) {
-  const self = this;
-  const bucket = config.destination;
-
-  bucket.acl.owners.addGroup('cloud-logs@google.com', function(err, apiResp) {
-    if (err) {
-      callback(err, null, apiResp);
-      return;
-    }
-
-    config.destination = 'storage.googleapis.com/' + bucket.name;
-
-    self.createSink(name, config, callback);
-  });
-};
-
-/**
- * This method is called when creating a sink with a Dataset destination. The
- * dataset must first grant proper ACL access to the Stackdriver Logging
- * account.
- *
- * The parameters are the same as what {@link Logging#createSink} accepts.
- *
- * @private
- */
-Logging.prototype.setAclForDataset_ = function(name, config, callback) {
-  const self = this;
-  const dataset = config.destination;
-
-  dataset.getMetadata(function(err, metadata, apiResp) {
-    if (err) {
-      callback(err, null, apiResp);
-      return;
-    }
-
-    const access = [].slice.call(arrify(metadata.access));
-
-    access.push({
-      role: 'WRITER',
-      groupByEmail: 'cloud-logs@google.com',
-    });
-
-    dataset.setMetadata(
+    delete reqOpts.autoPaginate;
+    delete reqOpts.gaxOptions;
+    const gaxOptions = extend(
       {
-        access: access,
+        autoPaginate: options.autoPaginate,
       },
-      function(err, apiResp) {
-        if (err) {
-          callback(err, null, apiResp);
-          return;
+      options.gaxOptions
+    );
+    this.request(
+      {
+        client: 'ConfigServiceV2Client',
+        method: 'listSinks',
+        reqOpts: reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      function() {
+        const sinks = arguments[1];
+        if (sinks) {
+          arguments[1] = sinks.map(function(sink) {
+            const sinkInstance = self.sink(sink.name);
+            sinkInstance.metadata = sink;
+            return sinkInstance;
+          });
         }
-
-        const baseUrl = 'bigquery.googleapis.com';
-        const pId = dataset.parent.projectId;
-        const dId = dataset.id;
-        config.destination = `${baseUrl}/projects/${pId}/datasets/${dId}`;
-        self.createSink(name, config, callback);
+        callback.apply(null, arguments);
       }
     );
-  });
-};
+  }
 
-/**
- * This method is called when creating a sink with a Topic destination. The
- * topic must first grant proper ACL access to the Stackdriver Logging account.
- *
- * The parameters are the same as what {@link Logging#createSink} accepts.
- *
- * @private
- */
-Logging.prototype.setAclForTopic_ = function(name, config, callback) {
-  const self = this;
-  const topic = config.destination;
-
-  topic.iam.getPolicy(function(err, policy, apiResp) {
-    if (err) {
-      callback(err, null, apiResp);
-      return;
-    }
-
-    policy.bindings = arrify(policy.bindings);
-
-    policy.bindings.push({
-      role: 'roles/pubsub.publisher',
-      members: ['serviceAccount:cloud-logs@system.gserviceaccount.com'],
+  /**
+   * Get the {@link Sink} objects associated with this project as a
+   * readable object stream.
+   *
+   * @method Logging#getSinksStream
+   * @param {GetSinksRequest} [query] Query object for listing sinks.
+   * @returns {ReadableStream} A readable stream that emits {@link Sink}
+   *     instances.
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   *
+   * logging.getSinksStream()
+   *   .on('error', console.error)
+   *   .on('data', function(sink) {
+   *     // `sink` is a Sink object.
+   *   })
+   *   .on('end', function() {
+   *     // All sinks retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * logging.getSinksStream()
+   *   .on('data', function(sink) {
+   *     this.end();
+   *   });
+   */
+  getSinksStream(options) {
+    const self = this;
+    options = options || {};
+    let requestStream;
+    const userStream = streamEvents(pumpify.obj());
+    userStream.abort = function() {
+      if (requestStream) {
+        requestStream.abort();
+      }
+    };
+    const toSinkStream = through.obj(function(sink, _, next) {
+      const sinkInstance = self.sink(sink.name);
+      sinkInstance.metadata = sink;
+      next(null, sinkInstance);
     });
+    userStream.once('reading', function() {
+      const reqOpts = extend({}, options, {
+        parent: 'projects/' + self.projectId,
+      });
+      delete reqOpts.gaxOptions;
+      const gaxOptions = extend(
+        {
+          autoPaginate: options.autoPaginate,
+        },
+        options.gaxOptions
+      );
+      requestStream = self.request({
+        client: 'ConfigServiceV2Client',
+        method: 'listSinksStream',
+        reqOpts: reqOpts,
+        gaxOpts: gaxOptions,
+      });
+      userStream.setPipeline(requestStream, toSinkStream);
+    });
+    return userStream;
+  }
 
-    topic.iam.setPolicy(policy, function(err, policy, apiResp) {
+  /**
+   * Get a reference to a Stackdriver Logging log.
+   *
+   * @see [Log Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs}
+   *
+   * @param {string} name Name of the existing log.
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.removeCircular] Replace circular references in
+   *     logged objects with a string value, `[Circular]`. (Default: false)
+   * @returns {Log}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   */
+  log(name, options) {
+    return new Log(this, name, options);
+  }
+
+  /**
+   * Get a reference to a Stackdriver Logging sink.
+   *
+   * @see [Sink Overview]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks}
+   *
+   * @param {string} name Name of the existing sink.
+   * @returns {Sink}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   */
+  sink(name) {
+    return new Sink(this, name);
+  }
+
+  /**
+   * Funnel all API requests through this method, to be sure we have a project ID.
+   *
+   * @param {object} config Configuration object.
+   * @param {object} config.gaxOpts GAX options.
+   * @param {function} config.method The gax method to call.
+   * @param {object} config.reqOpts Request options.
+   * @param {function} [callback] Callback function.
+   */
+  request(config, callback) {
+    const self = this;
+    const isStreamMode = !callback;
+    let gaxStream;
+    let stream;
+    if (isStreamMode) {
+      stream = streamEvents(through.obj());
+      stream.abort = function() {
+        if (gaxStream && gaxStream.cancel) {
+          gaxStream.cancel();
+        }
+      };
+      stream.once('reading', makeRequestStream);
+    } else {
+      makeRequestCallback();
+    }
+    function prepareGaxRequest(callback) {
+      self.auth.getProjectId(function(err, projectId) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        self.projectId = projectId;
+        let gaxClient = self.api[config.client];
+        if (!gaxClient) {
+          // Lazily instantiate client.
+          gaxClient = new v2[config.client](self.options);
+          self.api[config.client] = gaxClient;
+        }
+        let reqOpts = extend(true, {}, config.reqOpts);
+        reqOpts = replaceProjectIdToken(reqOpts, projectId);
+        const requestFn = gaxClient[config.method].bind(
+          gaxClient,
+          reqOpts,
+          config.gaxOpts
+        );
+        callback(null, requestFn);
+      });
+    }
+    function makeRequestCallback() {
+      if (global.GCLOUD_SANDBOX_ENV) {
+        return;
+      }
+      prepareGaxRequest(function(err, requestFn) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        requestFn(callback);
+      });
+    }
+    function makeRequestStream() {
+      if (global.GCLOUD_SANDBOX_ENV) {
+        return through.obj();
+      }
+      prepareGaxRequest(function(err, requestFn) {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+        gaxStream = requestFn();
+        gaxStream
+          .on('error', function(err) {
+            stream.destroy(err);
+          })
+          .pipe(stream);
+      });
+    }
+    return stream;
+  }
+
+  /**
+   * This method is called when creating a sink with a Bucket destination. The
+   * bucket must first grant proper ACL access to the Stackdriver Logging account.
+   *
+   * The parameters are the same as what {@link Logging#createSink} accepts.
+   *
+   * @private
+   */
+  setAclForBucket_(name, config, callback) {
+    const self = this;
+    const bucket = config.destination;
+    bucket.acl.owners.addGroup('cloud-logs@google.com', function(err, apiResp) {
       if (err) {
         callback(err, null, apiResp);
         return;
       }
-
-      const baseUrl = 'pubsub.googleapis.com';
-      const topicName = topic.name;
-      config.destination = `${baseUrl}/${topicName}`;
+      config.destination = 'storage.googleapis.com/' + bucket.name;
       self.createSink(name, config, callback);
     });
-  });
-};
+  }
+
+  /**
+   * This method is called when creating a sink with a Dataset destination. The
+   * dataset must first grant proper ACL access to the Stackdriver Logging
+   * account.
+   *
+   * The parameters are the same as what {@link Logging#createSink} accepts.
+   *
+   * @private
+   */
+  setAclForDataset_(name, config, callback) {
+    const self = this;
+    const dataset = config.destination;
+    dataset.getMetadata(function(err, metadata, apiResp) {
+      if (err) {
+        callback(err, null, apiResp);
+        return;
+      }
+      const access = [].slice.call(arrify(metadata.access));
+      access.push({
+        role: 'WRITER',
+        groupByEmail: 'cloud-logs@google.com',
+      });
+      dataset.setMetadata(
+        {
+          access: access,
+        },
+        function(err, apiResp) {
+          if (err) {
+            callback(err, null, apiResp);
+            return;
+          }
+          const baseUrl = 'bigquery.googleapis.com';
+          const pId = dataset.parent.projectId;
+          const dId = dataset.id;
+          config.destination = `${baseUrl}/projects/${pId}/datasets/${dId}`;
+          self.createSink(name, config, callback);
+        }
+      );
+    });
+  }
+
+  /**
+   * This method is called when creating a sink with a Topic destination. The
+   * topic must first grant proper ACL access to the Stackdriver Logging account.
+   *
+   * The parameters are the same as what {@link Logging#createSink} accepts.
+   *
+   * @private
+   */
+  setAclForTopic_(name, config, callback) {
+    const self = this;
+    const topic = config.destination;
+    topic.iam.getPolicy(function(err, policy, apiResp) {
+      if (err) {
+        callback(err, null, apiResp);
+        return;
+      }
+      policy.bindings = arrify(policy.bindings);
+      policy.bindings.push({
+        role: 'roles/pubsub.publisher',
+        members: ['serviceAccount:cloud-logs@system.gserviceaccount.com'],
+      });
+      topic.iam.setPolicy(policy, function(err, policy, apiResp) {
+        if (err) {
+          callback(err, null, apiResp);
+          return;
+        }
+        const baseUrl = 'pubsub.googleapis.com';
+        const topicName = topic.name;
+        config.destination = `${baseUrl}/${topicName}`;
+        self.createSink(name, config, callback);
+      });
+    });
+  }
+}
 
 /*! Developer Documentation
  *
@@ -979,7 +897,7 @@ promisifyAll(Logging, {
  * @see Entry
  * @type {Constructor}
  */
-Logging.Entry = Entry;
+module.exports.Entry = Entry;
 
 /**
  * {@link Log} class.
@@ -988,21 +906,7 @@ Logging.Entry = Entry;
  * @see Log
  * @type {Constructor}
  */
-Logging.Log = Log;
-
-/**
- * Reference to the {@link Logging} class.
- * @name module:@google-cloud/logging.Logging
- * @see Logging
- */
-/**
- * {@link Logging} class.
- *
- * @name Logging.Logging
- * @see Logging
- * @type {Constructor}
- */
-Logging.Logging = Logging;
+module.exports.Log = Log;
 
 /**
  * {@link Sink} class.
@@ -1011,7 +915,7 @@ Logging.Logging = Logging;
  * @see Sink
  * @type {Constructor}
  */
-Logging.Sink = Sink;
+module.exports.Sink = Sink;
 
 /**
  * The default export of the `@google-cloud/logging` package is the
@@ -1027,7 +931,7 @@ Logging.Sink = Sink;
  * npm install --save @google-cloud/logging
  *
  * @example <caption>Import the client library</caption>
- * const Logging = require('@google-cloud/logging');
+ * const {Logging} = require('@google-cloud/logging');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const logging = new Logging();
@@ -1042,7 +946,7 @@ Logging.Sink = Sink;
  * region_tag:logging_quickstart
  * Full quickstart example:
  */
-module.exports = Logging;
+module.exports.Logging = Logging;
 
 /**
  * Reference to the low-level auto-generated clients for the V2 Logging service.

--- a/src/log.js
+++ b/src/log.js
@@ -22,8 +22,8 @@ const extend = require('extend');
 const is = require('is');
 const snakeCaseKeys = require('snakecase-keys');
 
-const Entry = require('./entry.js');
-const Metadata = require('./metadata.js');
+const {Entry} = require('./entry');
+const {Metadata} = require('./metadata');
 
 /**
  * A log is a named collection of entries, each entry representing a timestamped
@@ -43,709 +43,700 @@ const Metadata = require('./metadata.js');
  *     logged objects with a string value, `[Circular]`. (Default: false)
  *
  * @example
- * const Logging = require('@google-cloud/logging');
+ * const {Logging} = require('@google-cloud/logging');
  * const logging = new Logging();
  * const log = logging.log('syslog');
  */
-function Log(logging, name, options) {
-  options = options || {};
+class Log {
+  constructor(logging, name, options) {
+    options = options || {};
+    this.formattedName_ = Log.formatName_(logging.projectId, name);
+    this.removeCircular_ = options.removeCircular === true;
+    this.metadata_ = new Metadata(logging);
+    this.logging = logging;
+    /**
+     * @name Log#name
+     * @type {string}
+     */
+    this.name = this.formattedName_.split('/').pop();
+  }
 
-  this.formattedName_ = Log.formatName_(logging.projectId, name);
-  this.removeCircular_ = options.removeCircular === true;
-  this.metadata_ = new Metadata(logging);
-
-  this.logging = logging;
   /**
-   * @name Log#name
-   * @type {string}
+   * Write a log entry with a severity of "ALERT".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.alert(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.alert(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
    */
-  this.name = this.formattedName_.split('/').pop();
-}
-
-/**
- * Return an array of log entries with the desired severity assigned.
- *
- * @private
- *
- * @param {object|object[]} entries - Log entries.
- * @param {string} severity - The desired severity level.
- */
-Log.assignSeverityToEntries_ = function(entries, severity) {
-  return arrify(entries).map(function(entry) {
-    const metadata = extend(true, {}, entry.metadata, {
-      severity: severity,
-    });
-
-    return extend(new Entry(), entry, {
-      metadata: metadata,
-    });
-  });
-};
-
-/**
- * Format the name of a log. A log's full name is in the format of
- * 'projects/{projectId}/logs/{logName}'.
- *
- * @private
- *
- * @returns {string}
- */
-Log.formatName_ = function(projectId, name) {
-  const path = 'projects/' + projectId + '/logs/';
-  name = name.replace(path, '');
-
-  if (decodeURIComponent(name) === name) {
-    // The name has not been encoded yet.
-    name = encodeURIComponent(name);
+  alert(entry, options, callback) {
+    this.write(Log.assignSeverityToEntries_(entry, 'ALERT'), options, callback);
   }
 
-  return path + name;
-};
-
-/**
- * Write a log entry with a severity of "ALERT".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.alert(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.alert(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.alert = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'ALERT'), options, callback);
-};
-
-/**
- * Write a log entry with a severity of "CRITICAL".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.critical(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.critical(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.critical = function(entry, options, callback) {
-  const entries = Log.assignSeverityToEntries_(entry, 'CRITICAL');
-  this.write(entries, options, callback);
-};
-
-/**
- * Write a log entry with a severity of "DEBUG".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.debug(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.debug(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.debug = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'DEBUG'), options, callback);
-};
-
-/**
- * @typedef {array} DeleteLogResponse
- * @property {object} 0 The full API response.
- */
-/**
- * @callback DeleteLogCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Delete the log.
- *
- * @see [projects.logs.delete API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs/delete}
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {DeleteLogCallback} [callback] Callback function.
- * @returns {Promise<DeleteLogResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * log.delete(function(err, apiResponse) {
- *   if (!err) {
- *     // The log was deleted.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.delete().then(function(data) {
- *   const apiResponse = data[0];
- * });
- *
- * @example <caption>include:samples/logs.js</caption>
- * region_tag:logging_delete_log
- * Another example:
- */
-Log.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+  /**
+   * Write a log entry with a severity of "CRITICAL".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.critical(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.critical(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  critical(entry, options, callback) {
+    const entries = Log.assignSeverityToEntries_(entry, 'CRITICAL');
+    this.write(entries, options, callback);
   }
 
-  const reqOpts = {
-    logName: this.formattedName_,
-  };
-
-  this.logging.request(
-    {
-      client: 'LoggingServiceV2Client',
-      method: 'deleteLog',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Write a log entry with a severity of "EMERGENCY".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.emergency(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.emergency(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.emergency = function(entry, options, callback) {
-  const entries = Log.assignSeverityToEntries_(entry, 'EMERGENCY');
-  this.write(entries, options, callback);
-};
-
-/**
- * Create an entry object for this log.
- *
- * Note that using this method will not itself make any API requests. You will
- * use the object returned in other API calls, such as
- * {@link Log#write}.
- *
- * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
- *
- * @param {?object} metadata See a
- *     [LogEntry Resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
- * @param {object|string} data The data to use as the value for this log
- *     entry.
- * @returns {Entry}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const metadata = {
- *   resource: {
- *     type: 'gce_instance',
- *     labels: {
- *       zone: 'global',
- *       instance_id: '3'
- *     }
- *   }
- * };
- *
- * const entry = log.entry(metadata, {
- *   delegate: 'my_username'
- * });
- *
- * entry.toJSON();
- * // {
- * //   logName: 'projects/grape-spaceship-123/logs/syslog',
- * //   resource: {
- * //     type: 'gce_instance',
- * //     labels: {
- * //       zone: 'global',
- * //       instance_id: '3'
- * //     }
- * //   },
- * //   jsonPayload: {
- * //     delegate: 'my_username'
- * //   }
- * // }
- */
-Log.prototype.entry = function(metadata, data) {
-  if (!data) {
-    data = metadata;
-    metadata = {};
+  /**
+   * Write a log entry with a severity of "DEBUG".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.debug(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.debug(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  debug(entry, options, callback) {
+    this.write(Log.assignSeverityToEntries_(entry, 'DEBUG'), options, callback);
   }
 
-  return this.logging.entry(metadata, data);
-};
-
-/**
- * Write a log entry with a severity of "ERROR".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.error(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.error(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.error = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'ERROR'), options, callback);
-};
-
-/**
- * This method is a wrapper around {module:logging#getEntries}, but with a
- * filter specified to only return entries from this log.
- *
- * @see [entries.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list}
- *
- * @param {GetEntriesRequest} [query] Query object for listing entries.
- * @param {GetEntriesCallback} [callback] Callback function.
- * @returns {Promise<GetEntriesResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * log.getEntries(function(err, entries) {
- *   // `entries` is an array of Stackdriver Logging entry objects.
- *   // See the `data` property to read the data from the entry.
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to `false`.
- * //-
- * function callback(err, entries, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     log.getEntries(nextQuery, callback);
- *   }
- * }
- *
- * log.getEntries({
- *   autoPaginate: false
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.getEntries().then(function(data) {
- *   const entries = data[0];
- * });
- */
-Log.prototype.getEntries = function(options, callback) {
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  options = extend(
-    {
-      filter: 'logName="' + this.formattedName_ + '"',
-    },
-    options
-  );
-
-  return this.logging.getEntries(options, callback);
-};
-
-/**
- * This method is a wrapper around {module:logging#getEntriesStream}, but with a
- * filter specified to only return {module:logging/entry} objects from this log.
- *
- * @method Log#getEntriesStream
- * @param {GetEntriesRequest} [query] Query object for listing entries.
- * @returns {ReadableStream} A readable stream that emits {@link Entry}
- *     instances.
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * log.getEntriesStream()
- *   .on('error', console.error)
- *   .on('data', function(entry) {
- *     // `entry` is a Stackdriver Logging entry object.
- *     // See the `data` property to read the data from the entry.
- *   })
- *   .on('end', function() {
- *     // All entries retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * log.getEntriesStream()
- *   .on('data', function(entry) {
- *     this.end();
- *   });
- */
-Log.prototype.getEntriesStream = function(options) {
-  options = extend(
-    {
-      filter: 'logName="' + this.formattedName_ + '"',
-    },
-    options
-  );
-
-  return this.logging.getEntriesStream(options);
-};
-
-/**
- * Write a log entry with a severity of "INFO".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.info(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.info(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.info = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'INFO'), options, callback);
-};
-
-/**
- * Write a log entry with a severity of "NOTICE".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.notice(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.notice(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.notice = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'NOTICE'), options, callback);
-};
-
-/**
- * Write a log entry with a severity of "WARNING".
- *
- * This is a simple wrapper around {@link Log#write}. All arguments are
- * the same as documented there.
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const log = logging.log('my-log');
- *
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.warning(entry, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.warning(entry).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Log.prototype.warning = function(entry, options, callback) {
-  this.write(Log.assignSeverityToEntries_(entry, 'WARNING'), options, callback);
-};
-
-/**
- * @typedef {array} LogWriteResponse
- * @property {object} 0 The full API response.
- */
-/**
- * @callback LogWriteCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Write options.
- *
- * @typedef {object} WriteOptions
- * @property {object} gaxOptions Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @property {object[]} labels Labels to set on the log.
- * @property {object} resource A default monitored resource for entries where
- *     one isn't specified.
- */
-/**
- * Write log entries to Stackdriver Logging.
- *
- * @see [entries.write API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write}
- *
- * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
- * @param {?WriteOptions} [options] Write options
- * @param {LogWriteCallback} [callback] Callback function.
- * @returns {Promise<LogWriteResponse>}
- *
- * @example
- * const entry = log.entry('gce_instance', {
- *   instance: 'my_instance'
- * });
- *
- * log.write(entry, function(err, apiResponse) {
- *   if (!err) {
- *     // The log entry was written.
- *   }
- * });
- *
- * //-
- * // You may also pass multiple log entries to write.
- * //-
- * const secondEntry = log.entry('compute.googleapis.com', {
- *   user: 'my_username'
- * });
- *
- * log.write([
- *   entry,
- *   secondEntry
- * ], function(err, apiResponse) {
- *   if (!err) {
- *     // The log entries were written.
- *   }
- * });
- *
- * //-
- * // To save some steps, you can also pass in plain values as your entries.
- * // Note, however, that you must provide a configuration object to specify the
- * // resource.
- * //-
- * const entries = [
- *   {
- *     user: 'my_username'
- *   },
- *   {
- *     home: process.env.HOME
- *   }
- * ];
- *
- * const options = {
- *   resource: 'compute.googleapis.com'
- * };
- *
- * log.write(entries, options, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * log.write(entries).then(function(data) {
- *   const apiResponse = data[0];
- * });
- *
- * @example <caption>include:samples/logs.js</caption>
- * region_tag:logging_write_log_entry
- * Another example:
- *
- * @example <caption>include:samples/logs.js</caption>
- * region_tag:logging_write_log_entry_advanced
- * Another example:
- */
-Log.prototype.write = function(entry, options, callback) {
-  const self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  if (!options.resource) {
-    this.metadata_.getDefaultResource(function(err, resource) {
-      // Ignore errors (the API will speak up if it has an issue).
-      writeWithResource(resource);
-    });
-  } else {
-    if (options.resource.labels) {
-      options.resource.labels = snakeCaseKeys(options.resource.labels);
+  /**
+   * @typedef {array} DeleteLogResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DeleteLogCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Delete the log.
+   *
+   * @see [projects.logs.delete API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs/delete}
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {DeleteLogCallback} [callback] Callback function.
+   * @returns {Promise<DeleteLogResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * log.delete(function(err, apiResponse) {
+   *   if (!err) {
+   *     // The log was deleted.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.delete().then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   *
+   * @example <caption>include:samples/logs.js</caption>
+   * region_tag:logging_delete_log
+   * Another example:
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-    writeWithResource(options.resource);
-  }
-
-  function writeWithResource(resource) {
-    let decoratedEntries;
-    try {
-      decoratedEntries = self.decorateEntries_(arrify(entry));
-    } catch (err) {
-      // Ignore errors (the API will speak up if it has an issue).
-    }
-
-    const reqOpts = extend(
-      {
-        logName: self.formattedName_,
-        entries: decoratedEntries,
-        resource: resource,
-      },
-      options
-    );
-
-    delete reqOpts.gaxOptions;
-
-    self.logging.request(
+    const reqOpts = {
+      logName: this.formattedName_,
+    };
+    this.logging.request(
       {
         client: 'LoggingServiceV2Client',
-        method: 'writeLogEntries',
+        method: 'deleteLog',
         reqOpts: reqOpts,
-        gaxOpts: options.gaxOptions,
+        gaxOpts: gaxOptions,
       },
       callback
     );
   }
-};
 
-/**
- * All entries are passed through here in order to get them serialized.
- *
- * @private
- *
- * @param {object[]} entries - Entry objects.
- * @returns {object[]} Serialized entries.
- * @throws if there is an error during serialization.
- */
-Log.prototype.decorateEntries_ = function(entries) {
-  const self = this;
+  /**
+   * Write a log entry with a severity of "EMERGENCY".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.emergency(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.emergency(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  emergency(entry, options, callback) {
+    const entries = Log.assignSeverityToEntries_(entry, 'EMERGENCY');
+    this.write(entries, options, callback);
+  }
 
-  return entries.map(function(entry) {
-    if (!(entry instanceof Entry)) {
-      entry = self.entry(entry);
+  /**
+   * Create an entry object for this log.
+   *
+   * Note that using this method will not itself make any API requests. You will
+   * use the object returned in other API calls, such as
+   * {@link Log#write}.
+   *
+   * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
+   *
+   * @param {?object} metadata See a
+   *     [LogEntry Resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+   * @param {object|string} data The data to use as the value for this log
+   *     entry.
+   * @returns {Entry}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const metadata = {
+   *   resource: {
+   *     type: 'gce_instance',
+   *     labels: {
+   *       zone: 'global',
+   *       instance_id: '3'
+   *     }
+   *   }
+   * };
+   *
+   * const entry = log.entry(metadata, {
+   *   delegate: 'my_username'
+   * });
+   *
+   * entry.toJSON();
+   * // {
+   * //   logName: 'projects/grape-spaceship-123/logs/syslog',
+   * //   resource: {
+   * //     type: 'gce_instance',
+   * //     labels: {
+   * //       zone: 'global',
+   * //       instance_id: '3'
+   * //     }
+   * //   },
+   * //   jsonPayload: {
+   * //     delegate: 'my_username'
+   * //   }
+   * // }
+   */
+  entry(metadata, data) {
+    if (!data) {
+      data = metadata;
+      metadata = {};
     }
+    return this.logging.entry(metadata, data);
+  }
 
-    return entry.toJSON({
-      removeCircular: self.removeCircular_,
+  /**
+   * Write a log entry with a severity of "ERROR".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.error(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.error(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  error(entry, options, callback) {
+    this.write(Log.assignSeverityToEntries_(entry, 'ERROR'), options, callback);
+  }
+
+  /**
+   * This method is a wrapper around {module:logging#getEntries}, but with a
+   * filter specified to only return entries from this log.
+   *
+   * @see [entries.list API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list}
+   *
+   * @param {GetEntriesRequest} [query] Query object for listing entries.
+   * @param {GetEntriesCallback} [callback] Callback function.
+   * @returns {Promise<GetEntriesResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * log.getEntries(function(err, entries) {
+   *   // `entries` is an array of Stackdriver Logging entry objects.
+   *   // See the `data` property to read the data from the entry.
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to `false`.
+   * //-
+   * function callback(err, entries, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     log.getEntries(nextQuery, callback);
+   *   }
+   * }
+   *
+   * log.getEntries({
+   *   autoPaginate: false
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.getEntries().then(function(data) {
+   *   const entries = data[0];
+   * });
+   */
+  getEntries(options, callback) {
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+    options = extend(
+      {
+        filter: 'logName="' + this.formattedName_ + '"',
+      },
+      options
+    );
+    return this.logging.getEntries(options, callback);
+  }
+
+  /**
+   * This method is a wrapper around {module:logging#getEntriesStream}, but with a
+   * filter specified to only return {module:logging/entry} objects from this log.
+   *
+   * @method Log#getEntriesStream
+   * @param {GetEntriesRequest} [query] Query object for listing entries.
+   * @returns {ReadableStream} A readable stream that emits {@link Entry}
+   *     instances.
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * log.getEntriesStream()
+   *   .on('error', console.error)
+   *   .on('data', function(entry) {
+   *     // `entry` is a Stackdriver Logging entry object.
+   *     // See the `data` property to read the data from the entry.
+   *   })
+   *   .on('end', function() {
+   *     // All entries retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing and API requests.
+   * //-
+   * log.getEntriesStream()
+   *   .on('data', function(entry) {
+   *     this.end();
+   *   });
+   */
+  getEntriesStream(options) {
+    options = extend(
+      {
+        filter: 'logName="' + this.formattedName_ + '"',
+      },
+      options
+    );
+    return this.logging.getEntriesStream(options);
+  }
+
+  /**
+   * Write a log entry with a severity of "INFO".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.info(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.info(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  info(entry, options, callback) {
+    this.write(Log.assignSeverityToEntries_(entry, 'INFO'), options, callback);
+  }
+
+  /**
+   * Write a log entry with a severity of "NOTICE".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.notice(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.notice(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  notice(entry, options, callback) {
+    this.write(
+      Log.assignSeverityToEntries_(entry, 'NOTICE'),
+      options,
+      callback
+    );
+  }
+
+  /**
+   * Write a log entry with a severity of "WARNING".
+   *
+   * This is a simple wrapper around {@link Log#write}. All arguments are
+   * the same as documented there.
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const log = logging.log('my-log');
+   *
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.warning(entry, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.warning(entry).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  warning(entry, options, callback) {
+    this.write(
+      Log.assignSeverityToEntries_(entry, 'WARNING'),
+      options,
+      callback
+    );
+  }
+
+  /**
+   * @typedef {array} LogWriteResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback LogWriteCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Write options.
+   *
+   * @typedef {object} WriteOptions
+   * @property {object} gaxOptions Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object[]} labels Labels to set on the log.
+   * @property {object} resource A default monitored resource for entries where
+   *     one isn't specified.
+   */
+  /**
+   * Write log entries to Stackdriver Logging.
+   *
+   * @see [entries.write API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write}
+   *
+   * @param {Entry|Entry[]} entry A log entry, or array of entries, to write.
+   * @param {?WriteOptions} [options] Write options
+   * @param {LogWriteCallback} [callback] Callback function.
+   * @returns {Promise<LogWriteResponse>}
+   *
+   * @example
+   * const entry = log.entry('gce_instance', {
+   *   instance: 'my_instance'
+   * });
+   *
+   * log.write(entry, function(err, apiResponse) {
+   *   if (!err) {
+   *     // The log entry was written.
+   *   }
+   * });
+   *
+   * //-
+   * // You may also pass multiple log entries to write.
+   * //-
+   * const secondEntry = log.entry('compute.googleapis.com', {
+   *   user: 'my_username'
+   * });
+   *
+   * log.write([
+   *   entry,
+   *   secondEntry
+   * ], function(err, apiResponse) {
+   *   if (!err) {
+   *     // The log entries were written.
+   *   }
+   * });
+   *
+   * //-
+   * // To save some steps, you can also pass in plain values as your entries.
+   * // Note, however, that you must provide a configuration object to specify the
+   * // resource.
+   * //-
+   * const entries = [
+   *   {
+   *     user: 'my_username'
+   *   },
+   *   {
+   *     home: process.env.HOME
+   *   }
+   * ];
+   *
+   * const options = {
+   *   resource: 'compute.googleapis.com'
+   * };
+   *
+   * log.write(entries, options, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * log.write(entries).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   *
+   * @example <caption>include:samples/logs.js</caption>
+   * region_tag:logging_write_log_entry
+   * Another example:
+   *
+   * @example <caption>include:samples/logs.js</caption>
+   * region_tag:logging_write_log_entry_advanced
+   * Another example:
+   */
+  write(entry, options, callback) {
+    const self = this;
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+    if (!options.resource) {
+      this.metadata_.getDefaultResource(function(err, resource) {
+        // Ignore errors (the API will speak up if it has an issue).
+        writeWithResource(resource);
+      });
+    } else {
+      if (options.resource.labels) {
+        options.resource.labels = snakeCaseKeys(options.resource.labels);
+      }
+      writeWithResource(options.resource);
+    }
+    function writeWithResource(resource) {
+      let decoratedEntries;
+      try {
+        decoratedEntries = self.decorateEntries_(arrify(entry));
+      } catch (err) {
+        // Ignore errors (the API will speak up if it has an issue).
+      }
+      const reqOpts = extend(
+        {
+          logName: self.formattedName_,
+          entries: decoratedEntries,
+          resource: resource,
+        },
+        options
+      );
+      delete reqOpts.gaxOptions;
+      self.logging.request(
+        {
+          client: 'LoggingServiceV2Client',
+          method: 'writeLogEntries',
+          reqOpts: reqOpts,
+          gaxOpts: options.gaxOptions,
+        },
+        callback
+      );
+    }
+  }
+
+  /**
+   * All entries are passed through here in order to get them serialized.
+   *
+   * @private
+   *
+   * @param {object[]} entries - Entry objects.
+   * @returns {object[]} Serialized entries.
+   * @throws if there is an error during serialization.
+   */
+  decorateEntries_(entries) {
+    const self = this;
+    return entries.map(function(entry) {
+      if (!(entry instanceof Entry)) {
+        entry = self.entry(entry);
+      }
+      return entry.toJSON({
+        removeCircular: self.removeCircular_,
+      });
     });
-  });
-};
+  }
+
+  /**
+   * Return an array of log entries with the desired severity assigned.
+   *
+   * @private
+   *
+   * @param {object|object[]} entries - Log entries.
+   * @param {string} severity - The desired severity level.
+   */
+  static assignSeverityToEntries_(entries, severity) {
+    return arrify(entries).map(function(entry) {
+      const metadata = extend(true, {}, entry.metadata, {
+        severity: severity,
+      });
+      return extend(new Entry(), entry, {
+        metadata: metadata,
+      });
+    });
+  }
+
+  /**
+   * Format the name of a log. A log's full name is in the format of
+   * 'projects/{projectId}/logs/{logName}'.
+   *
+   * @private
+   *
+   * @returns {string}
+   */
+  static formatName_(projectId, name) {
+    const path = 'projects/' + projectId + '/logs/';
+    name = name.replace(path, '');
+    if (decodeURIComponent(name) === name) {
+      // The name has not been encoded yet.
+      name = encodeURIComponent(name);
+    }
+    return path + name;
+  }
+}
 
 /*! Developer Documentation
  *
@@ -761,4 +752,4 @@ promisifyAll(Log, {
  * @name module:@google-cloud/logging.Log
  * @see Log
  */
-module.exports = Log;
+module.exports.Log = Log;

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -31,144 +31,144 @@ const gcpMetadata = require('gcp-metadata');
  *
  * @param {Logging} logging The parent Logging instance.
  */
-function Metadata(logging) {
-  this.logging = logging;
+class Metadata {
+  constructor(logging) {
+    this.logging = logging;
+  }
+  /**
+   * Retrieve a resource object describing the current environment.
+   *
+   * @param {function} callback Callback function.
+   */
+  getDefaultResource(callback) {
+    this.logging.auth
+      .getEnv()
+      .then(env => {
+        if (env === 'KUBERNETES_ENGINE') {
+          Metadata.getGKEDescriptor(callback);
+        } else if (env === 'APP_ENGINE') {
+          callback(null, Metadata.getGAEDescriptor());
+        } else if (env === 'CLOUD_FUNCTIONS') {
+          callback(null, Metadata.getCloudFunctionDescriptor());
+        } else if (env === 'COMPUTE_ENGINE') {
+          // Test for compute engine should be done after all the rest - everything
+          // runs on top of compute engine.
+          Metadata.getGCEDescriptor(callback);
+        } else {
+          callback(null, Metadata.getGlobalDescriptor());
+        }
+      })
+      .catch(callback);
+  }
+
+  /**
+   * Create a descriptor for Cloud Functions.
+   *
+   * @returns {object}
+   */
+  static getCloudFunctionDescriptor() {
+    return {
+      type: 'cloud_function',
+      labels: {
+        function_name: process.env.FUNCTION_NAME,
+        region: process.env.FUNCTION_REGION,
+      },
+    };
+  }
+
+  /**
+   * Create a descriptor for Google App Engine.
+   *
+   * @returns {object}
+   */
+  static getGAEDescriptor() {
+    return {
+      type: 'gae_app',
+      labels: {
+        module_id: process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME,
+        version_id: process.env.GAE_VERSION,
+      },
+    };
+  }
+
+  /**
+   * Create a descriptor for Google Compute Engine.
+   *
+   * @param {function} callback Callback function.
+   * @return {object}
+   */
+  static getGCEDescriptor(callback) {
+    gcpMetadata.instance('id').then(function(idResponse) {
+      gcpMetadata.instance('zone').then(function(zoneResponse) {
+        // Some parsing is necessary. Metadata service returns a fully
+        // qualified zone name: 'projects/{projectId}/zones/{zone}'. Logging
+        // wants just the zone part.
+        //
+        const zone = zoneResponse.data.split('/').pop();
+        callback(null, {
+          type: 'gce_instance',
+          labels: {
+            instance_id: idResponse.data,
+            zone: zone,
+          },
+        });
+      }, callback);
+    }, callback);
+  }
+
+  /**
+   * Create a descriptor for Google Container Engine.
+   *
+   * @param {function} callback Callback function.
+   * @return {object}
+   */
+  static getGKEDescriptor(callback) {
+    // Stackdriver Logging Monitored Resource for 'container' requires
+    // cluster_name and namespace_id fields. Note that these *need* to be
+    // snake_case. The namespace_id is not easily available from inside the
+    // container, but we can get the namespace_name. Logging has been using the
+    // namespace_name in place of namespace_id for a while now. Log correlation
+    // with metrics may not necessarily work however.
+    //
+    gcpMetadata.instance('attributes/cluster-name').then(function(resp) {
+      fs.readFile(
+        Metadata.KUBERNETES_NAMESPACE_ID_PATH,
+        'utf8',
+        (err, namespace) => {
+          if (err) {
+            callback(
+              new Error(
+                `Error reading ` +
+                  `${Metadata.KUBERNETES_NAMESPACE_ID_PATH}: ${err.message}`
+              )
+            );
+            return;
+          }
+          callback(null, {
+            type: 'container',
+            labels: {
+              cluster_name: resp.data,
+              namespace_id: namespace,
+            },
+          });
+        }
+      );
+    }, callback);
+  }
+
+  /**
+   * Create a global descriptor.
+   *
+   * @returns {object}
+   */
+  static getGlobalDescriptor() {
+    return {
+      type: 'global',
+    };
+  }
 }
 
 Metadata.KUBERNETES_NAMESPACE_ID_PATH =
   '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
-/**
- * Create a descriptor for Cloud Functions.
- *
- * @returns {object}
- */
-Metadata.getCloudFunctionDescriptor = function() {
-  return {
-    type: 'cloud_function',
-    labels: {
-      function_name: process.env.FUNCTION_NAME,
-      region: process.env.FUNCTION_REGION,
-    },
-  };
-};
-
-/**
- * Create a descriptor for Google App Engine.
- *
- * @returns {object}
- */
-Metadata.getGAEDescriptor = function() {
-  return {
-    type: 'gae_app',
-    labels: {
-      module_id: process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME,
-      version_id: process.env.GAE_VERSION,
-    },
-  };
-};
-
-/**
- * Create a descriptor for Google Compute Engine.
- *
- * @param {function} callback Callback function.
- * @return {object}
- */
-Metadata.getGCEDescriptor = function(callback) {
-  gcpMetadata.instance('id').then(function(idResponse) {
-    gcpMetadata.instance('zone').then(function(zoneResponse) {
-      // Some parsing is necessary. Metadata service returns a fully
-      // qualified zone name: 'projects/{projectId}/zones/{zone}'. Logging
-      // wants just the zone part.
-      //
-      const zone = zoneResponse.data.split('/').pop();
-      callback(null, {
-        type: 'gce_instance',
-        labels: {
-          instance_id: idResponse.data,
-          zone: zone,
-        },
-      });
-    }, callback);
-  }, callback);
-};
-
-/**
- * Create a descriptor for Google Container Engine.
- *
- * @param {function} callback Callback function.
- * @return {object}
- */
-Metadata.getGKEDescriptor = function(callback) {
-  // Stackdriver Logging Monitored Resource for 'container' requires
-  // cluster_name and namespace_id fields. Note that these *need* to be
-  // snake_case. The namespace_id is not easily available from inside the
-  // container, but we can get the namespace_name. Logging has been using the
-  // namespace_name in place of namespace_id for a while now. Log correlation
-  // with metrics may not necessarily work however.
-  //
-  gcpMetadata.instance('attributes/cluster-name').then(function(resp) {
-    fs.readFile(
-      Metadata.KUBERNETES_NAMESPACE_ID_PATH,
-      'utf8',
-      (err, namespace) => {
-        if (err) {
-          callback(
-            new Error(
-              `Error reading ` +
-                `${Metadata.KUBERNETES_NAMESPACE_ID_PATH}: ${err.message}`
-            )
-          );
-          return;
-        }
-
-        callback(null, {
-          type: 'container',
-          labels: {
-            cluster_name: resp.data,
-            namespace_id: namespace,
-          },
-        });
-      }
-    );
-  }, callback);
-};
-
-/**
- * Create a global descriptor.
- *
- * @returns {object}
- */
-Metadata.getGlobalDescriptor = function() {
-  return {
-    type: 'global',
-  };
-};
-
-/**
- * Retrieve a resource object describing the current environment.
- *
- * @param {function} callback Callback function.
- */
-Metadata.prototype.getDefaultResource = function(callback) {
-  this.logging.auth
-    .getEnv()
-    .then(env => {
-      if (env === 'KUBERNETES_ENGINE') {
-        Metadata.getGKEDescriptor(callback);
-      } else if (env === 'APP_ENGINE') {
-        callback(null, Metadata.getGAEDescriptor());
-      } else if (env === 'CLOUD_FUNCTIONS') {
-        callback(null, Metadata.getCloudFunctionDescriptor());
-      } else if (env === 'COMPUTE_ENGINE') {
-        // Test for compute engine should be done after all the rest - everything
-        // runs on top of compute engine.
-        Metadata.getGCEDescriptor(callback);
-      } else {
-        callback(null, Metadata.getGlobalDescriptor());
-      }
-    })
-    .catch(callback);
-};
-
-module.exports = Metadata;
+module.exports.Metadata = Metadata;

--- a/src/sink.js
+++ b/src/sink.js
@@ -36,318 +36,308 @@ const is = require('is');
  * @param {string} name Name of the sink.
  *
  * @example
- * const Logging = require('@google-cloud/logging');
+ * const {Logging} = require('@google-cloud/logging');
  * const logging = new Logging();
  * const sink = logging.sink('my-sink');
  */
-function Sink(logging, name) {
-  this.logging = logging;
+class Sink {
+  constructor(logging, name) {
+    this.logging = logging;
+    /**
+     * @name Sink#name
+     * @type {string}
+     */
+    this.name = name;
+    this.formattedName_ = 'projects/' + logging.projectId + '/sinks/' + name;
+  }
+
   /**
-   * @name Sink#name
-   * @type {string}
+   * Create a sink.
+   *
+   * @param {CreateSinkRequest} config Config to set for the sink.
+   * @param {CreateSinkCallback} [callback] Callback function.
+   * @returns {Promise<CreateSinkResponse>}
+   * @throws {Error} if a config object is not provided.
+   * @see Logging#createSink
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   *
+   * const config = {
+   *   destination: {
+   *     // ...
+   *   }
+   * };
+   *
+   * sink.create(config, function(err, sink, apiResponse) {
+   *   if (!err) {
+   *     // The sink was created successfully.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * sink.create(config).then(function(data) {
+   *   const sink = data[0];
+   *   const apiResponse = data[1];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_create_sink
+   * Another example:
    */
-  this.name = name;
-  this.formattedName_ = 'projects/' + logging.projectId + '/sinks/' + name;
-}
-
-/**
- * Create a sink.
- *
- * @param {CreateSinkRequest} config Config to set for the sink.
- * @param {CreateSinkCallback} [callback] Callback function.
- * @returns {Promise<CreateSinkResponse>}
- * @throws {Error} if a config object is not provided.
- * @see Logging#createSink
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- *
- * const config = {
- *   destination: {
- *     // ...
- *   }
- * };
- *
- * sink.create(config, function(err, sink, apiResponse) {
- *   if (!err) {
- *     // The sink was created successfully.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * sink.create(config).then(function(data) {
- *   const sink = data[0];
- *   const apiResponse = data[1];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_create_sink
- * Another example:
- */
-Sink.prototype.create = function(config, callback) {
-  this.logging.createSink(this.name, config, callback);
-};
-
-/**
- * @typedef {array} DeleteSinkResponse
- * @property {object} 0 The full API response.
- */
-/**
- * @callback DeleteSinkCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Delete the sink.
- *
- * @see [projects.sink.delete API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/delete}
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {DeleteSinkCallback} [callback] Callback function.
- * @returns {Promise<DeleteSinkResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- *
- * sink.delete(function(err, apiResponse) {
- *   if (!err) {
- *     // The log was deleted.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * sink.delete().then(function(data) {
- *   const apiResponse = data[0];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_delete_sink
- * Another example:
- */
-Sink.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+  create(config, callback) {
+    this.logging.createSink(this.name, config, callback);
   }
 
-  const reqOpts = {
-    sinkName: this.formattedName_,
-  };
-
-  this.logging.request(
-    {
-      client: 'ConfigServiceV2Client',
-      method: 'deleteSink',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * @typedef {array} GetSinkMetadataResponse
- * @property {object} 0 The {@link Sink} metadata.
- * @property {object} 1 The full API response.
- */
-/**
- * @callback GetSinkMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} metadata The {@link Sink} metadata.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Get the sink's metadata.
- *
- * @see [Sink Resource]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink}
- * @see [projects.sink.get API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/get}
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {GetSinkMetadataCallback} [callback] Callback function.
- * @returns {Promise<GetSinkMetadataResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- *
- * sink.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * sink.getMetadata().then(function(data) {
- *   const metadata = data[0];
- *   const apiResponse = data[1];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_get_sink
- * Another example:
- */
-Sink.prototype.getMetadata = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const reqOpts = {
-    sinkName: this.formattedName_,
-  };
-
-  this.logging.request(
-    {
-      client: 'ConfigServiceV2Client',
-      method: 'getSink',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        self.metadata = arguments[1];
-      }
-
-      callback.apply(null, arguments);
+  /**
+   * @typedef {array} DeleteSinkResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback DeleteSinkCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Delete the sink.
+   *
+   * @see [projects.sink.delete API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/delete}
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {DeleteSinkCallback} [callback] Callback function.
+   * @returns {Promise<DeleteSinkResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   *
+   * sink.delete(function(err, apiResponse) {
+   *   if (!err) {
+   *     // The log was deleted.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * sink.delete().then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_delete_sink
+   * Another example:
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-  );
-};
-
-/**
- * @typedef {array} SetSinkFilterResponse
- * @property {object} 0 The full API response.
- */
-/**
- * @callback SetSinkFilterCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Set the sink's filter.
- *
- * This will override any filter that was previously set.
- *
- * @see [Advanced Logs Filters]{@link https://cloud.google.com/logging/docs/view/advanced_filters}
- *
- * @param {string} filter The new filter.
- * @param {SetSinkFilterCallback} [callback] Callback function.
- * @returns {Promise<SetSinkFilterResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- *
- * const filter = 'metadata.severity = ALERT';
- *
- * sink.setFilter(filter, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * sink.setFilter(filter).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Sink.prototype.setFilter = function(filter, callback) {
-  this.setMetadata(
-    {
-      filter: filter,
-    },
-    callback
-  );
-};
-
-/**
- * @typedef {array} SetSinkMetadataResponse
- * @property {object} 0 The full API response.
- */
-/**
- * @callback SetSinkMetadataCallback
- * @param {?Error} err Request error, if any.
- * @param {object} apiResponse The full API response.
- */
-/**
- * Set the sink's metadata.
- *
- * @see [Sink Resource]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink}
- * @see [projects.sink.update API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/update}
- *
- * @param {object} metadata See a
- *     [Sink resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink).
- * @param {object} [metadata.gaxOptions] Request configuration options,
- *     outlined here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {SetSinkMetadataCallback} [callback] Callback function.
- * @returns {Promise<SetSinkMetadataResponse>}
- *
- * @example
- * const Logging = require('@google-cloud/logging');
- * const logging = new Logging();
- * const sink = logging.sink('my-sink');
- *
- * const metadata = {
- *   filter: 'metadata.severity = ALERT'
- * };
- *
- * sink.setMetadata(metadata, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * sink.setMetadata(metadata).then(function(data) {
- *   const apiResponse = data[0];
- * });
- *
- * @example <caption>include:samples/sinks.js</caption>
- * region_tag:logging_update_sink
- * Another example:
- */
-Sink.prototype.setMetadata = function(metadata, callback) {
-  const self = this;
-
-  callback = callback || common.util.noop;
-
-  this.getMetadata(function(err, currentMetadata, apiResponse) {
-    if (err) {
-      callback(err, apiResponse);
-      return;
-    }
-
     const reqOpts = {
-      sinkName: self.formattedName_,
-      sink: extend({}, currentMetadata, metadata),
+      sinkName: this.formattedName_,
     };
-
-    delete reqOpts.sink.gaxOptions;
-
-    self.logging.request(
+    this.logging.request(
       {
         client: 'ConfigServiceV2Client',
-        method: 'updateSink',
+        method: 'deleteSink',
         reqOpts: reqOpts,
-        gaxOpts: metadata.gaxOptions,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * @typedef {array} GetSinkMetadataResponse
+   * @property {object} 0 The {@link Sink} metadata.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetSinkMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} metadata The {@link Sink} metadata.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Get the sink's metadata.
+   *
+   * @see [Sink Resource]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink}
+   * @see [projects.sink.get API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/get}
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {GetSinkMetadataCallback} [callback] Callback function.
+   * @returns {Promise<GetSinkMetadataResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   *
+   * sink.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * sink.getMetadata().then(function(data) {
+   *   const metadata = data[0];
+   *   const apiResponse = data[1];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_get_sink
+   * Another example:
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+    const reqOpts = {
+      sinkName: this.formattedName_,
+    };
+    this.logging.request(
+      {
+        client: 'ConfigServiceV2Client',
+        method: 'getSink',
+        reqOpts: reqOpts,
+        gaxOpts: gaxOptions,
       },
       function() {
         if (arguments[1]) {
           self.metadata = arguments[1];
         }
-
         callback.apply(null, arguments);
       }
     );
-  });
-};
+  }
+
+  /**
+   * @typedef {array} SetSinkFilterResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback SetSinkFilterCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Set the sink's filter.
+   *
+   * This will override any filter that was previously set.
+   *
+   * @see [Advanced Logs Filters]{@link https://cloud.google.com/logging/docs/view/advanced_filters}
+   *
+   * @param {string} filter The new filter.
+   * @param {SetSinkFilterCallback} [callback] Callback function.
+   * @returns {Promise<SetSinkFilterResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   *
+   * const filter = 'metadata.severity = ALERT';
+   *
+   * sink.setFilter(filter, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * sink.setFilter(filter).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  setFilter(filter, callback) {
+    this.setMetadata(
+      {
+        filter: filter,
+      },
+      callback
+    );
+  }
+
+  /**
+   * @typedef {array} SetSinkMetadataResponse
+   * @property {object} 0 The full API response.
+   */
+  /**
+   * @callback SetSinkMetadataCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
+   * Set the sink's metadata.
+   *
+   * @see [Sink Resource]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink}
+   * @see [projects.sink.update API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/update}
+   *
+   * @param {object} metadata See a
+   *     [Sink resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink).
+   * @param {object} [metadata.gaxOptions] Request configuration options,
+   *     outlined here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {SetSinkMetadataCallback} [callback] Callback function.
+   * @returns {Promise<SetSinkMetadataResponse>}
+   *
+   * @example
+   * const {Logging} = require('@google-cloud/logging');
+   * const logging = new Logging();
+   * const sink = logging.sink('my-sink');
+   *
+   * const metadata = {
+   *   filter: 'metadata.severity = ALERT'
+   * };
+   *
+   * sink.setMetadata(metadata, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * sink.setMetadata(metadata).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   *
+   * @example <caption>include:samples/sinks.js</caption>
+   * region_tag:logging_update_sink
+   * Another example:
+   */
+  setMetadata(metadata, callback) {
+    const self = this;
+    callback = callback || common.util.noop;
+    this.getMetadata(function(err, currentMetadata, apiResponse) {
+      if (err) {
+        callback(err, apiResponse);
+        return;
+      }
+      const reqOpts = {
+        sinkName: self.formattedName_,
+        sink: extend({}, currentMetadata, metadata),
+      };
+      delete reqOpts.sink.gaxOptions;
+      self.logging.request(
+        {
+          client: 'ConfigServiceV2Client',
+          method: 'updateSink',
+          reqOpts: reqOpts,
+          gaxOpts: metadata.gaxOptions,
+        },
+        function() {
+          if (arguments[1]) {
+            self.metadata = arguments[1];
+          }
+          callback.apply(null, arguments);
+        }
+      );
+    });
+  }
+}
 
 /*! Developer Documentation
  *
@@ -361,4 +351,4 @@ promisifyAll(Sink);
  * @name module:@google-cloud/logging.Sink
  * @see Sink
  */
-module.exports = Sink;
+module.exports.Sink = Sink;

--- a/src/v2/config_service_v2_client.js
+++ b/src/v2/config_service_v2_client.js
@@ -253,7 +253,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -345,7 +345,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -396,7 +396,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -469,7 +469,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -566,7 +566,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -623,7 +623,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -687,7 +687,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -779,7 +779,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -830,7 +830,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -890,7 +890,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -963,7 +963,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.
@@ -1020,7 +1020,7 @@ class ConfigServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.ConfigServiceV2Client({
    *   // optional auth parameters.

--- a/src/v2/logging_service_v2_client.js
+++ b/src/v2/logging_service_v2_client.js
@@ -267,7 +267,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -379,7 +379,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -474,7 +474,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -590,7 +590,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -651,7 +651,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -736,7 +736,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -804,7 +804,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.
@@ -896,7 +896,7 @@ class LoggingServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.LoggingServiceV2Client({
    *   // optional auth parameters.

--- a/src/v2/metrics_service_v2_client.js
+++ b/src/v2/metrics_service_v2_client.js
@@ -242,7 +242,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.
@@ -331,7 +331,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.
@@ -377,7 +377,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.
@@ -432,7 +432,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.
@@ -493,7 +493,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.
@@ -543,7 +543,7 @@ class MetricsServiceV2Client {
    *
    * @example
    *
-   * const logging = require('@google-cloud/logging');
+   * const {Logging} = require('@google-cloud/logging');
    *
    * var client = new logging.v2.MetricsServiceV2Client({
    *   // optional auth parameters.

--- a/system-test/logging.js
+++ b/system-test/logging.js
@@ -18,24 +18,23 @@
 
 const assert = require('assert');
 const async = require('async');
-const bigqueryLibrary = require('@google-cloud/bigquery');
+const BigQuery = require('@google-cloud/bigquery');
 const exec = require('methmeth');
 const extend = require('extend');
 const is = require('is');
-const prop = require('propprop');
-const pubsubLibrary = require('@google-cloud/pubsub');
+const PubSub = require('@google-cloud/pubsub');
 const {Storage} = require('@google-cloud/storage');
 const uuid = require('uuid');
 
-const Logging = require('../');
+const {Logging} = require('../');
 
 describe('Logging', function() {
   let PROJECT_ID;
   const TESTS_PREFIX = 'gcloud-logging-test';
   const WRITE_CONSISTENCY_DELAY_MS = 10000;
 
-  const bigQuery = bigqueryLibrary();
-  const pubsub = pubsubLibrary();
+  const bigQuery = new BigQuery();
+  const pubsub = new PubSub();
   const storage = new Storage();
 
   const logging = new Logging();
@@ -393,7 +392,7 @@ describe('Logging', function() {
             function(err, entries) {
               assert.ifError(err);
 
-              assert.deepStrictEqual(entries.map(prop('data')).reverse(), [
+              assert.deepStrictEqual(entries.map(x => x.data).reverse(), [
                 'log entry 1',
                 {
                   delegate: 'my_username',
@@ -436,7 +435,7 @@ describe('Logging', function() {
               },
               function(err, entries) {
                 assert.ifError(err);
-                assert.deepStrictEqual(entries.map(prop('data')), [
+                assert.deepStrictEqual(entries.map(x => x.data), [
                   '3',
                   '2',
                   '1',
@@ -465,7 +464,7 @@ describe('Logging', function() {
           function(err, entries) {
             assert.ifError(err);
             assert.deepStrictEqual(
-              entries.reverse().map(prop('data')),
+              entries.reverse().map(x => x.data),
               messages
             );
             done();

--- a/test/entry.js
+++ b/test/entry.js
@@ -43,7 +43,7 @@ describe('Entry', function() {
         Service: FakeGrpcService,
       },
       eventid: FakeEventId,
-    });
+    }).Entry;
   });
 
   beforeEach(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -22,9 +22,7 @@ const extend = require('extend');
 const proxyquire = require('proxyquire');
 const through = require('through2');
 const {util} = require('@google-cloud/common-grpc');
-
-const v2 = require('../src/v2');
-
+const {v2} = require('../src');
 const PKG = require('../package.json');
 
 let extended = false;
@@ -120,20 +118,18 @@ describe('Logging', function() {
       'google-auth-library': {
         GoogleAuth: fakeGoogleAuth,
       },
-      './log.js': FakeLog,
-      './entry.js': FakeEntry,
-      './sink.js': FakeSink,
+      './log': {Log: FakeLog},
+      './entry': {Entry: FakeEntry},
+      './sink': {Sink: FakeSink},
       './v2': fakeV2,
-    });
+    }).Logging;
   });
 
   beforeEach(function() {
     extend(fakeUtil, originalFakeUtil);
-
     googleAuthOverride = null;
     isCustomTypeOverride = null;
     replaceProjectIdTokenOverride = null;
-
     logging = new Logging({
       projectId: PROJECT_ID,
     });
@@ -161,12 +157,6 @@ describe('Logging', function() {
 
     it('should promisify all the things', function() {
       assert(promisifed);
-    });
-
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        Logging({projectId: PROJECT_ID});
-      });
     });
 
     it('should initialize the API object', function() {
@@ -879,16 +869,12 @@ describe('Logging', function() {
         const fakeClient = {
           [CONFIG.method]: util.noop,
         };
-
         fakeV2[CONFIG.client] = function(options) {
           assert.strictEqual(options, logging.options);
           return fakeClient;
         };
-
         logging.api = {};
-
         logging.request(CONFIG, assert.ifError);
-
         assert.strictEqual(logging.api[CONFIG.client], fakeClient);
       });
 

--- a/test/log.js
+++ b/test/log.js
@@ -34,7 +34,7 @@ const fakePromisify = extend({}, promisify, {
   },
 });
 
-const Entry = require('../src/entry.js');
+const {Entry} = require('../src');
 
 function FakeMetadata() {
   this.calledWith_ = arguments;
@@ -59,11 +59,11 @@ describe('Log', function() {
   let assignSeverityToEntriesOverride = null;
 
   before(function() {
-    Log = proxyquire('../src/log.js', {
+    Log = proxyquire('../src/log', {
       '@google-cloud/promisify': fakePromisify,
-      './entry.js': Entry,
-      './metadata.js': FakeMetadata,
-    });
+      './entry': {Entry: Entry},
+      './metadata': {Metadata: FakeMetadata},
+    }).Log;
     const assignSeverityToEntries_ = Log.assignSeverityToEntries_;
     Log.assignSeverityToEntries_ = function() {
       return (

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -67,10 +67,10 @@ describe('metadata', function() {
   const ENV_CACHED = extend({}, process.env);
 
   before(function() {
-    Metadata = proxyquire('../src/metadata.js', {
+    Metadata = proxyquire('../src/metadata', {
       'gcp-metadata': fakeGcpMetadata,
       fs: fakeFS,
-    });
+    }).Metadata;
 
     MetadataCached = extend({}, Metadata);
   });

--- a/test/sink.js
+++ b/test/sink.js
@@ -42,9 +42,9 @@ describe('Sink', function() {
   const SINK_NAME = 'sink-name';
 
   before(function() {
-    Sink = proxyquire('../src/sink.js', {
+    Sink = proxyquire('../src/sink', {
       '@google-cloud/promisify': fakePromisify,
-    });
+    }).Sink;
   });
 
   beforeEach(function() {


### PR DESCRIPTION
BREAKING CHANGE: This library is now compatible with es module import syntax.  

#### Old Code
```js
const logging = require('@google-cloud/logging')();
// or...
const Logging = require('@google-cloud/logging');
const logging = new Logging();
```

#### New Code
```js
const {Logging} = require('@google-cloud/logging');
const logging = new Logging();
```
