### PR TITLE
build: write logs to separate file

### DIFF
--- a/system-test/logging.js
+++ b/system-test/logging.js
@@ -281,7 +281,7 @@ describe('Logging', () => {
   });
 
   describe('logs', () => {
-    const log = logging.log('systestlog');
+    const log = logging.log(`system-test-logs-${uuid.v4()}`);
 
     const logEntries = [
       // string data
@@ -314,6 +314,8 @@ describe('Logging', () => {
         },
       },
     };
+
+    after(done => log.delete(done));
 
     it('should list log entries', done => {
       logging.getEntries(

--- a/system-test/logging.js
+++ b/system-test/logging.js
@@ -281,7 +281,7 @@ describe('Logging', () => {
   });
 
   describe('logs', () => {
-    const log = logging.log('syslog');
+    const log = logging.log('systestlog');
 
     const logEntries = [
       // string data


### PR DESCRIPTION
We're seeing some unexpected errors come up in our syslog file. This PR runs tests against a different log file to prevent unexpected results.

@JustinBeckwith I'm not sure if we should continue to dig into the error we're seeing, but it seems to be related to the CI environment and not the client library itself.

```sh
Sep 20 07:44:04 verdaccio puppet-agent[659]: Could not request certificate: Failed to open TCP connection to puppet:8140
```

