### PR TITLE
Release @google-cloud/logging v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [1]: https://www.npmjs.com/package/nodejs-logging?activeTab=versions
 
+## v4.0.1
+
+### Implementation Changes
+- fix(deps): Upgrade to @google-cloud/common-grpc 0.9.0 ([#232](https://github.com/googleapis/nodejs-logging/pull/232))
+
 ## v4.0.0
 
 **This release has breaking changes**. This library is now compatible with es module import syntax.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "nyc mocha system-test/ test/"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.0.0",
+    "@google-cloud/logging": "^4.0.1",
     "@google-cloud/logging-bunyan": "^0.9.0",
     "@google-cloud/logging-winston": "^0.9.0",
     "@google-cloud/storage": "^2.0.2",


### PR DESCRIPTION
This pull request was generated using releasetool.