### PR TITLE
refactor: introduce typescript compiler

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     80

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "node": ">=6.0.0"
   },
   "repository": "googleapis/nodejs-logging",
-  "main": "./src/index.js",
+  "main": "./build/src/index.js",
   "files": [
-    "protos",
-    "src",
+    "build",
     "AUTHORS",
     "CONTRIBUTORS",
     "LICENSE"
@@ -51,16 +50,23 @@
     "greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>"
   ],
   "scripts": {
-    "cover": "nyc --reporter=lcov mocha test/*.js && nyc report",
-    "test-no-cover": "mocha test/*.js",
+    "cover": "nyc --reporter=lcov mocha build/test/*.js && nyc report",
+    "test-no-cover": "mocha build/test/*.js",
     "test": "npm run cover",
     "docs": "jsdoc -c .jsdoc.js",
     "prettier": "prettier --write src/*.js src/**/*.js test/*.js test/**/*.js samples/*.js samples/**/*.js system-test/*.js system-test/**/*.js",
     "publish-module": "node ../../scripts/publish.js logging",
-    "system-test": "mocha system-test/*.js --timeout 600000",
+    "system-test": "mocha build/system-test/*.js --timeout 600000",
     "samples-test": "cd samples/ && npm test && cd ../",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "lint": "eslint src/ samples/ system-test/ test/"
+    "lint": "eslint samples/",
+    "check": "echo \"gts check disabled until ts migration is complete\"",
+    "clean": "gts clean",
+    "compile": "tsc -p . && cp src/v2/*.json build/src/v2 && cp -r protos build",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
   },
   "dependencies": {
     "@google-cloud/common-grpc": "^0.9.0",
@@ -105,6 +111,8 @@
     "prettier": "^1.14.2",
     "propprop": "^0.3.1",
     "proxyquire": "^2.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "gts": "^0.8.0",
+    "typescript": "~3.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const pumpify = require('pumpify');
 const streamEvents = require('stream-events');
 const through = require('through2');
 
-const PKG = require('../package.json');
+const PKG = require('../../package.json');
 const v2 = require('./v2');
 
 const {Entry} = require('./entry');

--- a/src/v2/config_service_v2_client.js
+++ b/src/v2/config_service_v2_client.js
@@ -19,7 +19,7 @@ const gax = require('google-gax');
 const merge = require('lodash.merge');
 const path = require('path');
 
-const VERSION = require('../../package.json').version;
+const VERSION = require('../../../package.json').version;
 
 /**
  * Service for configuring sinks used to export log entries outside of

--- a/src/v2/logging_service_v2_client.js
+++ b/src/v2/logging_service_v2_client.js
@@ -20,7 +20,7 @@ const merge = require('lodash.merge');
 const path = require('path');
 const protobuf = require('protobufjs');
 
-const VERSION = require('../../package.json').version;
+const VERSION = require('../../../package.json').version;
 
 /**
  * Service for ingesting and querying logs.

--- a/src/v2/metrics_service_v2_client.js
+++ b/src/v2/metrics_service_v2_client.js
@@ -19,7 +19,7 @@ const gax = require('google-gax');
 const merge = require('lodash.merge');
 const path = require('path');
 
-const VERSION = require('../../package.json').version;
+const VERSION = require('../../../package.json').version;
 
 /**
  * Service for configuring logs-based metrics.

--- a/synth.py
+++ b/synth.py
@@ -34,6 +34,17 @@ v2_library = gapic.node_library(
 
 s.copy(v2_library, excludes=["src/index.js", "README.md", "package.json"])
 
+s.replace(
+    "src/v2/config_service_v2_client.js", "../../package.json", "../../../package.json"
+)
+s.replace(
+    "src/v2/logging_service_v2_client.js", "../../package.json", "../../../package.json"
+)
+s.replace(
+    "src/v2/metrics_service_v2_client.js", "../../package.json", "../../../package.json"
+)
+
+
 templates = common_templates.node_library()
 s.copy(templates)
 

--- a/system-test/logging.js
+++ b/system-test/logging.js
@@ -27,7 +27,7 @@ const PubSub = require('@google-cloud/pubsub');
 const {Storage} = require('@google-cloud/storage');
 const uuid = require('uuid');
 
-const {Logging} = require('../');
+const {Logging} = require('../src/index');
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock('http://metadata.google.internal')

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ const proxyquire = require('proxyquire');
 const through = require('through2');
 const {util} = require('@google-cloud/common-grpc');
 const {v2} = require('../src');
-const PKG = require('../package.json');
+const PKG = require('../../package.json');
 
 let extended = false;
 const fakePaginator = {
@@ -108,7 +108,7 @@ describe('Logging', () => {
   const PROJECT_ID = 'project-id';
 
   before(() => {
-    Logging = proxyquire('../', {
+    Logging = proxyquire('../../', {
       '@google-cloud/common-grpc': {
         util: fakeUtil,
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "allowJs": true,
+    "declaration": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/*.ts",
+    "src/*/js",
+    "src/**/*.ts",
+    "src/**/*.js",
+    "test/*.ts",
+    "test/*.js",
+    "test/**/*.ts",
+    "test/**/*.js",
+    "system-test/*.ts",
+    "system-test/*.js",
+    "system-test/**/*.ts",
+    "system-test/**/*.js"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "gts/tslint.json"
+}


### PR DESCRIPTION
Use TypeScript compiler with the `allowJs` option. With the toolchain
in place we can start migrating the files incrementally.
