### PR TITLE
fix: resolve compile errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@google-cloud/bigquery": "*",
     "@google-cloud/nodejs-repo-tools": "^2.3.3",
     "@google-cloud/pubsub": "^0.20.1",
-    "@google-cloud/storage": "^2.0.2",
+    "@google-cloud/storage": "^2.2.0",
     "@types/arrify": "^1.0.4",
     "@types/express": "^4.16.0",
     "@types/extend": "^3.0.0",

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -165,7 +165,8 @@ describe('Logging', () => {
         const logstream = logging.getSinksStream({pageSize: 1})
                               .on('error', done)
                               .once('data', () => {
-                                logstream.end();
+                                // tslint:disable-next-line no-any
+                                (logstream as any).end();
                                 done();
                               });
       });


### PR DESCRIPTION
`master` was not compiling on my machine. This change picks up the latest `@google-cloud/storage` package with fixed types. Secondly, the `getSinksStream` is inferred to be typed as a `Stream` which doesn't have an `end` method. Even a `Readable` is not supposed to have an `end` method. Either way, fix the compile error by papering over it.