### PR TITLE
fix(middleware): tweak the middleware api

### DIFF
--- a/src/middleware/express/make-middleware.ts
+++ b/src/middleware/express/make-middleware.ts
@@ -32,7 +32,7 @@ export interface AnnotatedRequestType<LoggerType> extends Request {
  * libraries such as winston and bunyan.
  *
  * @param projectId Generated traceIds will be associated with this project.
- * @param makeChildLogger A function that generates a logger instances that will
+ * @param makeChildLogger A function that generates logger instances that will
  * be installed onto `req` as `req.log`. The logger should include the trace in
  * each log entry's metadata (associated with the LOGGING_TRACE_KEY property.
  * @param emitRequestLog Optional. A function that will emit a parent request

--- a/src/middleware/express/make-middleware.ts
+++ b/src/middleware/express/make-middleware.ts
@@ -21,17 +21,30 @@ import {Request, Response, NextFunction} from 'express';
 import {makeHttpRequestData} from './make-http-request';
 import {StackdriverHttpRequest} from '../../http-request';
 
-const CHILD_LOG_NAME_SUFFIX = 'applog';
-
 export interface AnnotatedRequestType<LoggerType> extends Request {
   log: LoggerType;
 }
 
+/**
+ * Generates an express middleware that installs a request-specific logger on
+ * the `request` object. It optionally can do HttpRequest timing that can be
+ * used for generating request logs. This can be used to integrate with logging
+ * libraries such as winston and bunyan.
+ *
+ * @param projectId Generated traceIds will be associated with this project.
+ * @param makeChildLogger A function that generates a logger instances that will
+ * be installed onto `req` as `req.log`. The logger should include the trace in
+ * each log entry's metadata (associated with the LOGGING_TRACE_KEY property.
+ * @param emitRequestLog Optional. A function that will emit a parent request
+ * log. While some environments like GAE and GCF emit parent request logs
+ * automatically, other environments do not. When provided this function will be
+ * called with a populated `StackdriverHttpRequest` which can be emitted as
+ * request log.
+ */
 export function makeMiddleware<LoggerType>(
-    projectId: string,
-    emitRequestLog: (httpRequest: StackdriverHttpRequest, trace: string) =>
-        void,
-    makeChildLogger: (childSuffix: string, trace: string) => LoggerType) {
+    projectId: string, makeChildLogger: (trace: string) => LoggerType,
+    emitRequestLog?: (httpRequest: StackdriverHttpRequest, trace: string) =>
+        void) {
   return (req: Request, res: Response, next: NextFunction) => {
     // TODO(ofrobots): use high-resolution timer.
     const requestStartMs = Date.now();
@@ -42,15 +55,16 @@ export function makeMiddleware<LoggerType>(
     const trace = `projects/${projectId}/traces/${spanContext.traceId}`;
 
     // Install a child logger on the request object.
-    (req as AnnotatedRequestType<LoggerType>).log =
-        makeChildLogger(CHILD_LOG_NAME_SUFFIX, trace);
+    (req as AnnotatedRequestType<LoggerType>).log = makeChildLogger(trace);
 
-    // Emit a 'Request Log' on the parent logger.
-    onFinished(res, () => {
-      const latencyMs = Date.now() - requestStartMs;
-      const httpRequest = makeHttpRequestData(req, res, latencyMs);
-      emitRequestLog(httpRequest, trace);
-    });
+    if (emitRequestLog) {
+      // Emit a 'Request Log' on the parent logger.
+      onFinished(res, () => {
+        const latencyMs = Date.now() - requestStartMs;
+        const httpRequest = makeHttpRequestData(req, res, latencyMs);
+        emitRequestLog(httpRequest, trace);
+      });
+    }
 
     next();
   };

--- a/test/middleware/express/test-make-middleware.ts
+++ b/test/middleware/express/test-make-middleware.ts
@@ -46,7 +46,7 @@ describe('middleware/express/make-middleware', () => {
         {'../context': FAKE_CONTEXT});
 
     it('should return a function accepting 3 arguments', () => {
-      const middleware = makeMiddleware(FAKE_PROJECT_ID, () => {}, () => {});
+      const middleware = makeMiddleware(FAKE_PROJECT_ID, () => {});
       assert.ok(typeof middleware === 'function');
       assert.ok(middleware.length === 3);
     });
@@ -64,7 +64,7 @@ describe('middleware/express/make-middleware', () => {
         const fakeResponse = makeFakeResponse();
         let called = false;
 
-        const middleware = makeMiddleware(FAKE_PROJECT_ID, () => {}, () => {});
+        const middleware = makeMiddleware(FAKE_PROJECT_ID, () => {});
 
         middleware(fakeRequest, fakeResponse, () => {
           called = true;
@@ -78,16 +78,15 @@ describe('middleware/express/make-middleware', () => {
         const fakeRequest = makeFakeRequest();
         const fakeResponse = makeFakeResponse();
 
-        function makeChild(childSuffix, trace) {
+        function makeChild(trace) {
           assert.strictEqual(
               trace,
               `projects/${FAKE_PROJECT_ID}/traces/${
                   FAKE_SPAN_CONTEXT.traceId}`);
-          assert.strictEqual(typeof childSuffix, 'string');
           return FAKE_CHILD_LOGGER;
         }
 
-        const middleware = makeMiddleware(FAKE_PROJECT_ID, () => {}, makeChild);
+        const middleware = makeMiddleware(FAKE_PROJECT_ID, makeChild);
         middleware(fakeRequest, fakeResponse, () => {});
 
         // Should annotate the request with the child logger.
@@ -111,7 +110,7 @@ describe('middleware/express/make-middleware', () => {
         }
 
         const middleware =
-            makeMiddleware(FAKE_PROJECT_ID, emitRequestLog, () => {});
+            makeMiddleware(FAKE_PROJECT_ID, () => {}, emitRequestLog);
         middleware(fakeRequest, fakeResponse, () => {});
 
         setTimeout(() => {


### PR DESCRIPTION
* Child suffix is not necessary.
* Make emitRequestLog optional. Make it control finish tracking.
