### PR TITLE
refactor: go back to prettier, use generated gapic tests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,9 +2,12 @@
 extends:
   - 'eslint:recommended'
   - 'plugin:node/recommended'
+  - prettier
 plugins:
   - node
+  - prettier
 rules:
+  prettier/prettier: error
   block-scoped-var: error
   eqeqeq: error
   no-warning-comments: warn

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/*
+samples/node_modules/*
+src/**/doc/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+---
+bracketSpacing: false
+printWidth: 80
+semi: true
+singleQuote: true
+tabWidth: 2
+trailingComma: es5
+useTabs: false

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "lint": "gts check && eslint samples/",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r src/v2 build/src/v2 && cp -r protos build",
-    "fix": "gts fix && gts fix samples/*.js samples/test/*.js",
+    "compile": "tsc -p . && cp -r src/v2 build/src/v2 && cp -r protos build && cp test/*.js build/test",
+    "fix": "gts fix && eslint --fix 'samples/*.js' 'samples/**/*.js'",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check"
@@ -110,7 +110,9 @@
     "bignumber.js": "^7.2.1",
     "codecov": "^3.0.4",
     "eslint": "^5.4.0",
+    "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "gts": "^0.8.0",
     "ink-docstrap": "git+https://github.com/docstrap/docstrap.git",
     "intelli-espower-loader": "^1.0.1",
@@ -119,6 +121,7 @@
     "nock": "^10.0.1",
     "nyc": "^13.0.1",
     "power-assert": "^1.6.0",
+    "prettier": "^1.15.1",
     "proxyquire": "^2.1.0",
     "typescript": "~3.1.0",
     "uuid": "^3.3.2"

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -42,21 +42,25 @@ function writeLogEntry(logName) {
   const entry = log.entry({resource: resource}, 'Hello, world!');
 
   // A structured log entry
-  const secondEntry = log.entry({resource: resource}, {
-    name: 'King Arthur',
-    quest: 'Find the Holy Grail',
-    favorite_color: 'Blue',
-  });
+  const secondEntry = log.entry(
+    {resource: resource},
+    {
+      name: 'King Arthur',
+      quest: 'Find the Holy Grail',
+      favorite_color: 'Blue',
+    }
+  );
 
   // Save the two log entries. You can write entries one at a time, but it is
   // best to write multiple entires together in a batch.
-  log.write([entry, secondEntry])
-      .then(() => {
-        console.log(`Wrote to ${logName}`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  log
+    .write([entry, secondEntry])
+    .then(() => {
+      console.log(`Wrote to ${logName}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_write_log_entry]
 }
 
@@ -84,13 +88,14 @@ function writeLogEntryAdvanced(logName, options) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/log?method=write
-  log.write(entry)
-      .then(() => {
-        console.log(`Wrote to ${logName}`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  log
+    .write(entry)
+    .then(() => {
+      console.log(`Wrote to ${logName}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_write_log_entry_advanced]
 }
 
@@ -112,19 +117,20 @@ function listLogEntries(logName) {
   // List the most recent entries for a given log
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging?method=getEntries
-  log.getEntries()
-      .then(results => {
-        const entries = results[0];
+  log
+    .getEntries()
+    .then(results => {
+      const entries = results[0];
 
-        console.log('Logs:');
-        entries.forEach(entry => {
-          const metadata = entry.metadata;
-          console.log(`${metadata.timestamp}:`, metadata[metadata.payload]);
-        });
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
+      console.log('Logs:');
+      entries.forEach(entry => {
+        const metadata = entry.metadata;
+        console.log(`${metadata.timestamp}:`, metadata[metadata.payload]);
       });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_list_log_entries]
 }
 
@@ -155,19 +161,20 @@ function listLogEntriesAdvanced(filter, pageSize, orderBy) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging?method=getEntries
-  logging.getEntries(options)
-      .then(results => {
-        const entries = results[0];
+  logging
+    .getEntries(options)
+    .then(results => {
+      const entries = results[0];
 
-        console.log('Logs:');
-        entries.forEach(entry => {
-          const metadata = entry.metadata;
-          console.log(`${metadata.timestamp}:`, metadata[metadata.payload]);
-        });
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
+      console.log('Logs:');
+      entries.forEach(entry => {
+        const metadata = entry.metadata;
+        console.log(`${metadata.timestamp}:`, metadata[metadata.payload]);
       });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [START logging_list_log_entries_advanced]
 }
 
@@ -190,95 +197,102 @@ function deleteLog(logName) {
   // Note that a deletion can take several minutes to take effect.
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/log?method=delete
-  log.delete()
-      .then(() => {
-        console.log(`Deleted log: ${logName}`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  log
+    .delete()
+    .then(() => {
+      console.log(`Deleted log: ${logName}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_delete_log]
 }
 
 require(`yargs`)
-    .demand(1)
-    .command(
-        'list',
-        'Lists log entries, optionally filtering, limiting, and sorting results.',
-        {
-          filter: {
-            alias: 'f',
-            type: 'string',
-            requiresArg: true,
-            description: 'Only log entries matching the filter are written.',
-          },
-          limit: {
-            alias: 'l',
-            type: 'number',
-            requiresArg: true,
-            description: 'Maximum number of results to return.',
-          },
-          sort: {
-            alias: 's',
-            type: 'string',
-            requiresArg: true,
-            description: 'Sort results.',
-          },
-        },
-        opts => {
-          listLogEntriesAdvanced(opts.filter, opts.limit, opts.sort);
-        })
-    .command(
-        'list-simple <logName>', 'Lists log entries.', {},
-        opts => listLogEntries(opts.logName))
-    .command(
-        'write <logName> <resource> <entry>',
-        'Writes a log entry to the specified log.', {},
-        opts => {
-          try {
-            opts.resource = JSON.parse(opts.resource);
-          } catch (err) {
-            console.error('"resource" must be a valid JSON string!');
-            return;
-          }
+  .demand(1)
+  .command(
+    'list',
+    'Lists log entries, optionally filtering, limiting, and sorting results.',
+    {
+      filter: {
+        alias: 'f',
+        type: 'string',
+        requiresArg: true,
+        description: 'Only log entries matching the filter are written.',
+      },
+      limit: {
+        alias: 'l',
+        type: 'number',
+        requiresArg: true,
+        description: 'Maximum number of results to return.',
+      },
+      sort: {
+        alias: 's',
+        type: 'string',
+        requiresArg: true,
+        description: 'Sort results.',
+      },
+    },
+    opts => {
+      listLogEntriesAdvanced(opts.filter, opts.limit, opts.sort);
+    }
+  )
+  .command('list-simple <logName>', 'Lists log entries.', {}, opts =>
+    listLogEntries(opts.logName)
+  )
+  .command(
+    'write <logName> <resource> <entry>',
+    'Writes a log entry to the specified log.',
+    {},
+    opts => {
+      try {
+        opts.resource = JSON.parse(opts.resource);
+      } catch (err) {
+        console.error('"resource" must be a valid JSON string!');
+        return;
+      }
 
-          try {
-            opts.entry = JSON.parse(opts.entry);
-          } catch (err) {
-            console.error('"entry" must be a valid JSON string!');
-            return;
-          }
+      try {
+        opts.entry = JSON.parse(opts.entry);
+      } catch (err) {
+        console.error('"entry" must be a valid JSON string!');
+        return;
+      }
 
-          writeLogEntryAdvanced(opts.logName, opts);
-        })
-    .command(
-        'write-simple <logName>',
-        'Writes a basic log entry to the specified log.', {},
-        opts => {
-          writeLogEntry(opts.logName);
-        })
-    .command(
-        'delete <logName>', 'Deletes the specified Log.', {},
-        opts => {
-          deleteLog(opts.logName);
-        })
-    .example('node $0 list', 'List all log entries.')
-    .example(
-        'node $0 list -f "severity=ERROR" -s "timestamp" -l 2',
-        'List up to 2 error entries, sorted by timestamp ascending.')
-    .example(
-        `node $0 list -f 'logName="my-log"' -l 2`,
-        'List up to 2 log entries from the "my-log" log.')
-    .example(
-        'node $0 write my-log \'{"type":"gae_app","labels":{"module_id":"default"}}\' \'"Hello World!"\'',
-        'Write a string log entry.')
-    .example(
-        'node $0 write my-log \'{"type":"global"}\' \'{"message":"Hello World!"}\'',
-        'Write a JSON log entry.')
-    .example('node $0 delete my-log', 'Delete "my-log".')
-    .wrap(120)
-    .recommendCommands()
-    .epilogue(`For more information, see https://cloud.google.com/logging/docs`)
-    .help()
-    .strict()
-    .argv;
+      writeLogEntryAdvanced(opts.logName, opts);
+    }
+  )
+  .command(
+    'write-simple <logName>',
+    'Writes a basic log entry to the specified log.',
+    {},
+    opts => {
+      writeLogEntry(opts.logName);
+    }
+  )
+  .command('delete <logName>', 'Deletes the specified Log.', {}, opts => {
+    deleteLog(opts.logName);
+  })
+  .example('node $0 list', 'List all log entries.')
+  .example(
+    'node $0 list -f "severity=ERROR" -s "timestamp" -l 2',
+    'List up to 2 error entries, sorted by timestamp ascending.'
+  )
+  .example(
+    `node $0 list -f 'logName="my-log"' -l 2`,
+    'List up to 2 log entries from the "my-log" log.'
+  )
+  .example(
+    'node $0 write my-log \'{"type":"gae_app","labels":{"module_id":"default"}}\' \'"Hello World!"\'',
+    'Write a string log entry.'
+  )
+  .example(
+    'node $0 write my-log \'{"type":"global"}\' \'{"message":"Hello World!"}\'',
+    'Write a JSON log entry.'
+  )
+  .example('node $0 delete my-log', 'Delete "my-log".')
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/logging/docs`)
+  .help()
+  .strict().argv;

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -36,17 +36,18 @@ const log = logging.log(logName);
 const text = 'Hello, world!';
 // The metadata associated with the entry
 const metadata = {
-  resource: {type: 'global'}
+  resource: {type: 'global'},
 };
 // Prepares a log entry
 const entry = log.entry(metadata, text);
 
 // Writes the log entry
-log.write(entry)
-    .then(() => {
-      console.log(`Logged: ${text}`);
-    })
-    .catch(err => {
-      console.error('ERROR:', err);
-    });
+log
+  .write(entry)
+  .then(() => {
+    console.log(`Logged: ${text}`);
+  })
+  .catch(err => {
+    console.error('ERROR:', err);
+  });
 // [END logging_quickstart]

--- a/samples/sinks.js
+++ b/samples/sinks.js
@@ -53,13 +53,14 @@ function createSink(sinkName, bucketName, filter) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/sink?method=create
-  sink.create(config)
-      .then(() => {
-        console.log(`Created sink ${sinkName} to ${bucketName}`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  sink
+    .create(config)
+    .then(() => {
+      console.log(`Created sink ${sinkName} to ${bucketName}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_create_sink]
 }
 
@@ -80,17 +81,18 @@ function getSinkMetadata(sinkName) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/sink?method=getMetadata
-  sink.getMetadata()
-      .then(results => {
-        const metadata = results[0];
+  sink
+    .getMetadata()
+    .then(results => {
+      const metadata = results[0];
 
-        console.log(`Name: ${metadata.name}`);
-        console.log(`Destination: ${metadata.destination}`);
-        console.log(`Filter: ${metadata.filter}`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+      console.log(`Name: ${metadata.name}`);
+      console.log(`Destination: ${metadata.destination}`);
+      console.log(`Filter: ${metadata.filter}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_get_sink]
 }
 
@@ -104,20 +106,21 @@ function listSinks() {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging?method=getSinks
-  logging.getSinks()
-      .then(results => {
-        const sinks = results[0];
+  logging
+    .getSinks()
+    .then(results => {
+      const sinks = results[0];
 
-        console.log('Sinks:');
-        sinks.forEach(sink => {
-          console.log(sink.name);
-          console.log(`  Destination: ${sink.metadata.destination}`);
-          console.log(`  Filter: ${sink.metadata.filter}`);
-        });
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
+      console.log('Sinks:');
+      sinks.forEach(sink => {
+        console.log(sink.name);
+        console.log(`  Destination: ${sink.metadata.destination}`);
+        console.log(`  Filter: ${sink.metadata.filter}`);
       });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_list_sinks]
 }
 
@@ -150,14 +153,15 @@ function updateSink(sinkName, filter) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/sink?method=setMetadata
-  sink.setMetadata(metadata)
-      .then(results => {
-        const metadata = results[0];
-        console.log(`Sink ${sinkName} updated.`, metadata);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  sink
+    .setMetadata(metadata)
+    .then(results => {
+      const metadata = results[0];
+      console.log(`Sink ${sinkName} updated.`, metadata);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_update_sink]
 }
 
@@ -178,57 +182,66 @@ function deleteSink(sinkName) {
 
   // See
   // https://googlecloudplatform.github.io/google-cloud-node/#/docs/logging/latest/logging/sink?method=delete
-  sink.delete()
-      .then(() => {
-        console.log(`Sink ${sinkName} deleted.`);
-      })
-      .catch(err => {
-        console.error('ERROR:', err);
-      });
+  sink
+    .delete()
+    .then(() => {
+      console.log(`Sink ${sinkName} deleted.`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
   // [END logging_delete_sink]
 }
 
 require(`yargs`)
-    .demand(1)
-    .command(
-        'create <sinkName> <bucketName> [filter]',
-        'Creates a new sink with the given name to the specified bucket with an optional filter.',
-        {},
-        opts => {
-          createSink(opts.sinkName, opts.bucketName, opts.filter);
-        })
-    .command(
-        'get <sinkName>', 'Gets the metadata for the specified sink.', {},
-        opts => {
-          getSinkMetadata(opts.sinkName);
-        })
-    .command('list', 'Lists all sinks.', {}, listSinks)
-    .command(
-        'update <sinkName> <filter>',
-        'Updates the filter for the specified sink.', {},
-        opts => {
-          updateSink(opts.sinkName, opts.filter);
-        })
-    .command(
-        'delete <sinkName>', 'Deletes the specified sink.', {},
-        opts => {
-          deleteSink(opts.sinkName);
-        })
-    .example(
-        'node $0 create export-errors app-error-logs',
-        'Create a new sink named "export-errors" that exports logs to a bucket named "app-error-logs".')
-    .example(
-        'node $0 get export-errors',
-        'Get the metadata for a sink name "export-errors".')
-    .example('node $0 list', 'List all sinks.')
-    .example(
-        'node $0 update export-errors "severity >= WARNING"',
-        'Update the filter for a sink named "export-errors".')
-    .example(
-        'node $0 delete export-errors', 'Delete a sink named "export-errors".')
-    .wrap(120)
-    .recommendCommands()
-    .epilogue(`For more information, see https://cloud.google.com/logging/docs`)
-    .help()
-    .strict()
-    .argv;
+  .demand(1)
+  .command(
+    'create <sinkName> <bucketName> [filter]',
+    'Creates a new sink with the given name to the specified bucket with an optional filter.',
+    {},
+    opts => {
+      createSink(opts.sinkName, opts.bucketName, opts.filter);
+    }
+  )
+  .command(
+    'get <sinkName>',
+    'Gets the metadata for the specified sink.',
+    {},
+    opts => {
+      getSinkMetadata(opts.sinkName);
+    }
+  )
+  .command('list', 'Lists all sinks.', {}, listSinks)
+  .command(
+    'update <sinkName> <filter>',
+    'Updates the filter for the specified sink.',
+    {},
+    opts => {
+      updateSink(opts.sinkName, opts.filter);
+    }
+  )
+  .command('delete <sinkName>', 'Deletes the specified sink.', {}, opts => {
+    deleteSink(opts.sinkName);
+  })
+  .example(
+    'node $0 create export-errors app-error-logs',
+    'Create a new sink named "export-errors" that exports logs to a bucket named "app-error-logs".'
+  )
+  .example(
+    'node $0 get export-errors',
+    'Get the metadata for a sink name "export-errors".'
+  )
+  .example('node $0 list', 'List all sinks.')
+  .example(
+    'node $0 update export-errors "severity >= WARNING"',
+    'Update the filter for a sink named "export-errors".'
+  )
+  .example(
+    'node $0 delete export-errors',
+    'Delete a sink named "export-errors".'
+  )
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/logging/docs`)
+  .help()
+  .strict().argv;

--- a/samples/system-test/logs.test.js
+++ b/samples/system-test/logs.test.js
@@ -32,8 +32,9 @@ before(async () => {
 
 it(`should write a log entry`, async () => {
   const output = await tools.runAsync(
-      `${cmd} write ${logName} '{"type":"global"}' '{"message":"${message}"}'`,
-      cwd);
+    `${cmd} write ${logName} '{"type":"global"}' '{"message":"${message}"}'`,
+    cwd
+  );
   assert.strictEqual(output, `Wrote to ${logName}`);
 });
 

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -29,8 +29,7 @@ const logName = `nodejs-docs-samples-test-${uuid.v4()}`;
 after(async () => {
   try {
     await logging.log(logName).delete();
-  } catch (err) {
-  }  // ignore error
+  } catch (err) {} // ignore error
 });
 
 beforeEach(tools.stubConsole);

--- a/samples/system-test/sinks.test.js
+++ b/samples/system-test/sinks.test.js
@@ -40,17 +40,17 @@ before(async () => {
 after(async () => {
   try {
     await logging.sink(sinkName).delete();
-  } catch (err) {
-  }  // ignore error
+  } catch (err) {} // ignore error
   try {
     await storage.bucket(bucketName).delete();
-  } catch (err) {
-  }  // ignore error
+  } catch (err) {} // ignore error
 });
 
 it(`should create a sink`, async () => {
   const output = await tools.runAsync(
-      `${cmd} create ${sinkName} ${bucketName} "${filter}"`, cwd);
+    `${cmd} create ${sinkName} ${bucketName} "${filter}"`,
+    cwd
+  );
   assert.strictEqual(output, `Created sink ${sinkName} to ${bucketName}`);
   const [metadata] = await logging.sink(sinkName).getMetadata();
   assert.strictEqual(metadata.name, sinkName);
@@ -65,18 +65,20 @@ it(`should get a sink`, async () => {
 
 it(`should list sinks`, async () => {
   await tools
-      .tryTest(async assert => {
-        const output = await tools.runAsync(`${cmd} list`, cwd);
-        assert(output.includes(`Sinks:`));
-        assert(output.includes(sinkName));
-      })
-      .start();
+    .tryTest(async assert => {
+      const output = await tools.runAsync(`${cmd} list`, cwd);
+      assert(output.includes(`Sinks:`));
+      assert(output.includes(sinkName));
+    })
+    .start();
 });
 
 it(`should update a sink`, async () => {
   const newFilter = 'severity >= WARNING';
-  const output =
-      await tools.runAsync(`${cmd} update ${sinkName} "${newFilter}"`, cwd);
+  const output = await tools.runAsync(
+    `${cmd} update ${sinkName} "${newFilter}"`,
+    cwd
+  );
   assert(output.indexOf(`Sink ${sinkName} updated.`) > -1);
   const [metadata] = await logging.sink(sinkName).getMetadata();
   assert.strictEqual(metadata.name, sinkName);

--- a/samples/test/fluent.test.js
+++ b/samples/test/fluent.test.js
@@ -44,10 +44,10 @@ it(`should log error`, done => {
   });
 
   request(app)
-      .get(`/`)
-      .expect(500)
-      .expect(() => {
-        assert(loggerCalled, `structuredLogger.emit should have been called`);
-      })
-      .end(done);
+    .get(`/`)
+    .expect(500)
+    .expect(() => {
+      assert(loggerCalled, `structuredLogger.emit should have been called`);
+    })
+    .end(done);
 });

--- a/src/v2/config_service_v2_client.js
+++ b/src/v2/config_service_v2_client.js
@@ -49,10 +49,8 @@ class ConfigServiceV2Client {
    *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
    *     the environment variable GCLOUD_PROJECT for your project ID. If your
    *     app is running in an environment which supports
-   *     {@link
-   * https://developers.google.com/identity/protocols/application-default-credentials
-   * Application Default Credentials}, your project ID will be detected
-   * automatically.
+   *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+   *     your project ID will be detected automatically.
    * @param {function} [options.promise] - Custom promise module to use instead
    *     of native Promises.
    * @param {string} [options.servicePath] - The domain name of the
@@ -63,12 +61,13 @@ class ConfigServiceV2Client {
 
     // Ensure that options include the service address and port.
     opts = Object.assign(
-        {
-          clientConfig: {},
-          port: this.constructor.port,
-          servicePath: this.constructor.servicePath,
-        },
-        opts);
+      {
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      },
+      opts
+    );
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
@@ -91,34 +90,51 @@ class ConfigServiceV2Client {
 
     // Load the applicable protos.
     const protos = merge(
-        {},
-        gaxGrpc.loadProto(
-            path.join(__dirname, '..', '..', 'protos'),
-            'google/logging/v2/logging_config.proto'));
+      {},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'google/logging/v2/logging_config.proto'
+      )
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gax.PathTemplate('projects/{project}'),
-      sinkPathTemplate: new gax.PathTemplate('projects/{project}/sinks/{sink}'),
-      exclusionPathTemplate:
-          new gax.PathTemplate('projects/{project}/exclusions/{exclusion}'),
+      projectPathTemplate: new gax.PathTemplate(
+        'projects/{project}'
+      ),
+      sinkPathTemplate: new gax.PathTemplate(
+        'projects/{project}/sinks/{sink}'
+      ),
+      exclusionPathTemplate: new gax.PathTemplate(
+        'projects/{project}/exclusions/{exclusion}'
+      ),
     };
 
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listSinks: new gax.PageDescriptor('pageToken', 'nextPageToken', 'sinks'),
-      listExclusions:
-          new gax.PageDescriptor('pageToken', 'nextPageToken', 'exclusions'),
+      listSinks: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'sinks'
+      ),
+      listExclusions: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'exclusions'
+      ),
     };
 
     // Put together the default options sent with requests.
     const defaults = gaxGrpc.constructSettings(
-        'google.logging.v2.ConfigServiceV2', gapicConfig, opts.clientConfig,
-        {'x-goog-api-client': clientHeader.join(' ')});
+      'google.logging.v2.ConfigServiceV2',
+      gapicConfig,
+      opts.clientConfig,
+      {'x-goog-api-client': clientHeader.join(' ')}
+    );
 
     // Set up a dictionary of "inner API calls"; the core implementation
     // of calling the API is handled in `google-gax`, with this code
@@ -127,8 +143,10 @@ class ConfigServiceV2Client {
 
     // Put together the "service stub" for
     // google.logging.v2.ConfigServiceV2.
-    const configServiceV2Stub =
-        gaxGrpc.createStub(protos.google.logging.v2.ConfigServiceV2, opts);
+    const configServiceV2Stub = gaxGrpc.createStub(
+      protos.google.logging.v2.ConfigServiceV2,
+      opts
+    );
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -146,11 +164,16 @@ class ConfigServiceV2Client {
     ];
     for (const methodName of configServiceV2StubMethods) {
       this._innerApiCalls[methodName] = gax.createApiCall(
-          configServiceV2Stub.then(stub => function() {
-            const args = Array.prototype.slice.call(arguments, 0);
-            return stub[methodName].apply(stub, args);
-          }),
-          defaults[methodName], this._descriptors.page[methodName]);
+        configServiceV2Stub.then(
+          stub =>
+            function() {
+              const args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }
+        ),
+        defaults[methodName],
+        this._descriptors.page[methodName]
+      );
     }
   }
 
@@ -214,40 +237,27 @@ class ConfigServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is Array of [LogSink]{@link
-   google.logging.v2.LogSink}.
+   *   The second parameter to the callback is Array of [LogSink]{@link google.logging.v2.LogSink}.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListSinksResponse]{@link google.logging.v2.ListSinksResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListSinksResponse]{@link google.logging.v2.ListSinksResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of [LogSink]{@link
-   google.logging.v2.LogSink}.
+   *   The first element of the array is Array of [LogSink]{@link google.logging.v2.LogSink}.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
-   *   The first element is Array of [LogSink]{@link google.logging.v2.LogSink}
-   in a single response.
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [LogSink]{@link google.logging.v2.LogSink} in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListSinksResponse]{@link
-   google.logging.v2.ListSinksResponse}.
+   *   an object representing [ListSinksResponse]{@link google.logging.v2.ListSinksResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -311,8 +321,7 @@ class ConfigServiceV2Client {
    * Equivalent to {@link listSinks}, but returns a NodeJS Stream object.
    *
    * This fetches the paged responses for {@link listSinks} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -337,14 +346,10 @@ class ConfigServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
-   *   An object stream which emits an object representing [LogSink]{@link
-   google.logging.v2.LogSink} on 'data' event.
+   *   An object stream which emits an object representing [LogSink]{@link google.logging.v2.LogSink} on 'data' event.
    *
    * @example
    *
@@ -366,7 +371,10 @@ class ConfigServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listSinks.createStream(
-        this._innerApiCalls.listSinks, request, options);
+      this._innerApiCalls.listSinks,
+      request,
+      options
+    );
   };
 
   /**
@@ -384,21 +392,15 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogSink]{@link google.logging.v2.LogSink}.
+   *   The second parameter to the callback is an object representing [LogSink]{@link google.logging.v2.LogSink}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [LogSink]{@link
-   google.logging.v2.LogSink}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogSink]{@link google.logging.v2.LogSink}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -449,39 +451,29 @@ class ConfigServiceV2Client {
    *   Required. The new sink, whose `name` parameter is a sink identifier that
    *   is not already in use.
    *
-   *   This object should have the same structure as [LogSink]{@link
-   google.logging.v2.LogSink}
+   *   This object should have the same structure as [LogSink]{@link google.logging.v2.LogSink}
    * @param {boolean} [request.uniqueWriterIdentity]
-   *   Optional. Determines the kind of IAM identity returned as
-   `writer_identity`
+   *   Optional. Determines the kind of IAM identity returned as `writer_identity`
    *   in the new sink.  If this value is omitted or set to false, and if the
-   *   sink's parent is a project, then the value returned as `writer_identity`
-   is
+   *   sink's parent is a project, then the value returned as `writer_identity` is
    *   the same group or service account used by Logging before the
    *   addition of writer identities to this API. The sink's destination must be
    *   in the same project as the sink itself.
    *
    *   If this field is set to true, or if the sink is owned by a non-project
-   *   resource such as an organization, then the value of `writer_identity`
-   will
+   *   resource such as an organization, then the value of `writer_identity` will
    *   be a unique service account used only for exports from the new sink.  For
    *   more information, see `writer_identity` in LogSink.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogSink]{@link google.logging.v2.LogSink}.
+   *   The second parameter to the callback is an object representing [LogSink]{@link google.logging.v2.LogSink}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [LogSink]{@link
-   google.logging.v2.LogSink}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogSink]{@link google.logging.v2.LogSink}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -535,20 +527,15 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
    * @param {Object} request.sink
-   *   Required. The updated sink, whose name is the same identifier that
-   appears
+   *   Required. The updated sink, whose name is the same identifier that appears
    *   as part of `sink_name`.
    *
-   *   This object should have the same structure as [LogSink]{@link
-   google.logging.v2.LogSink}
+   *   This object should have the same structure as [LogSink]{@link google.logging.v2.LogSink}
    * @param {boolean} [request.uniqueWriterIdentity]
    *   Optional. See
-   *
-   [sinks.create](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/create)
-   *   for a description of this field.  When updating a sink, the effect of
-   this
-   *   field on the value of `writer_identity` in the updated sink depends on
-   both
+   *   [sinks.create](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/create)
+   *   for a description of this field.  When updating a sink, the effect of this
+   *   field on the value of `writer_identity` in the updated sink depends on both
    *   the old and new values of this field:
    *
    *   +   If the old and new values of this field are both false or both true,
@@ -569,29 +556,21 @@ class ConfigServiceV2Client {
    *   empty updateMask will be an error.
    *
    *   For a detailed `FieldMask` definition, see
-   *
-   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
+   *   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
    *
    *   Example: `updateMask=filter`.
    *
-   *   This object should have the same structure as [FieldMask]{@link
-   google.protobuf.FieldMask}
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogSink]{@link google.logging.v2.LogSink}.
+   *   The second parameter to the callback is an object representing [LogSink]{@link google.logging.v2.LogSink}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [LogSink]{@link
-   google.logging.v2.LogSink}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogSink]{@link google.logging.v2.LogSink}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -643,16 +622,12 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error)} [callback]
    *   The function which will be called with the result of the API call.
    * @returns {Promise} - The promise which resolves when API call finishes.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -696,40 +671,27 @@ class ConfigServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is Array of [LogExclusion]{@link
-   google.logging.v2.LogExclusion}.
+   *   The second parameter to the callback is Array of [LogExclusion]{@link google.logging.v2.LogExclusion}.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListExclusionsResponse]{@link google.logging.v2.ListExclusionsResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListExclusionsResponse]{@link google.logging.v2.ListExclusionsResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of [LogExclusion]{@link
-   google.logging.v2.LogExclusion}.
+   *   The first element of the array is Array of [LogExclusion]{@link google.logging.v2.LogExclusion}.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
-   *   The first element is Array of [LogExclusion]{@link
-   google.logging.v2.LogExclusion} in a single response.
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [LogExclusion]{@link google.logging.v2.LogExclusion} in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListExclusionsResponse]{@link
-   google.logging.v2.ListExclusionsResponse}.
+   *   an object representing [ListExclusionsResponse]{@link google.logging.v2.ListExclusionsResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -793,8 +755,7 @@ class ConfigServiceV2Client {
    * Equivalent to {@link listExclusions}, but returns a NodeJS Stream object.
    *
    * This fetches the paged responses for {@link listExclusions} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -819,14 +780,10 @@ class ConfigServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
-   *   An object stream which emits an object representing [LogExclusion]{@link
-   google.logging.v2.LogExclusion} on 'data' event.
+   *   An object stream which emits an object representing [LogExclusion]{@link google.logging.v2.LogExclusion} on 'data' event.
    *
    * @example
    *
@@ -848,7 +805,10 @@ class ConfigServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listExclusions.createStream(
-        this._innerApiCalls.listExclusions, request, options);
+      this._innerApiCalls.listExclusions,
+      request,
+      options
+    );
   };
 
   /**
@@ -866,21 +826,15 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The second parameter to the callback is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -930,24 +884,17 @@ class ConfigServiceV2Client {
    *   Required. The new exclusion, whose `name` parameter is an exclusion name
    *   that is not already used in the parent resource.
    *
-   *   This object should have the same structure as [LogExclusion]{@link
-   google.logging.v2.LogExclusion}
+   *   This object should have the same structure as [LogExclusion]{@link google.logging.v2.LogExclusion}
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The second parameter to the callback is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -997,12 +944,10 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
    * @param {Object} request.exclusion
-   *   Required. New values for the existing exclusion. Only the fields
-   specified
+   *   Required. New values for the existing exclusion. Only the fields specified
    *   in `update_mask` are relevant.
    *
-   *   This object should have the same structure as [LogExclusion]{@link
-   google.logging.v2.LogExclusion}
+   *   This object should have the same structure as [LogExclusion]{@link google.logging.v2.LogExclusion}
    * @param {Object} request.updateMask
    *   Required. A nonempty list of fields to change in the existing exclusion.
    *   New values for the fields are taken from the corresponding fields in the
@@ -1012,24 +957,17 @@ class ConfigServiceV2Client {
    *   For example, to change the filter and description of an exclusion,
    *   specify an `update_mask` of `"filter,description"`.
    *
-   *   This object should have the same structure as [FieldMask]{@link
-   google.protobuf.FieldMask}
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The second parameter to the callback is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogExclusion]{@link google.logging.v2.LogExclusion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogExclusion]{@link google.logging.v2.LogExclusion}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -1081,16 +1019,12 @@ class ConfigServiceV2Client {
    *
    *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error)} [callback]
    *   The function which will be called with the result of the API call.
    * @returns {Promise} - The promise which resolves when API call finishes.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -1167,7 +1101,9 @@ class ConfigServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromProjectName(projectName) {
-    return this._pathTemplates.projectPathTemplate.match(projectName).project;
+    return this._pathTemplates.projectPathTemplate
+      .match(projectName)
+      .project;
   }
 
   /**
@@ -1178,7 +1114,9 @@ class ConfigServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromSinkName(sinkName) {
-    return this._pathTemplates.sinkPathTemplate.match(sinkName).project;
+    return this._pathTemplates.sinkPathTemplate
+      .match(sinkName)
+      .project;
   }
 
   /**
@@ -1189,7 +1127,9 @@ class ConfigServiceV2Client {
    * @returns {String} - A string representing the sink.
    */
   matchSinkFromSinkName(sinkName) {
-    return this._pathTemplates.sinkPathTemplate.match(sinkName).sink;
+    return this._pathTemplates.sinkPathTemplate
+      .match(sinkName)
+      .sink;
   }
 
   /**
@@ -1200,8 +1140,9 @@ class ConfigServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromExclusionName(exclusionName) {
-    return this._pathTemplates.exclusionPathTemplate.match(exclusionName)
-        .project;
+    return this._pathTemplates.exclusionPathTemplate
+      .match(exclusionName)
+      .project;
   }
 
   /**
@@ -1212,8 +1153,9 @@ class ConfigServiceV2Client {
    * @returns {String} - A string representing the exclusion.
    */
   matchExclusionFromExclusionName(exclusionName) {
-    return this._pathTemplates.exclusionPathTemplate.match(exclusionName)
-        .exclusion;
+    return this._pathTemplates.exclusionPathTemplate
+      .match(exclusionName)
+      .exclusion;
   }
 }
 

--- a/src/v2/doc/google/api/doc_distribution.js
+++ b/src/v2/doc/google/api/doc_distribution.js
@@ -55,15 +55,13 @@
  *   If specified, contains the range of the population values. The field
  *   must not be present if the `count` is zero.
  *
- *   This object should have the same structure as [Range]{@link
- * google.api.Range}
+ *   This object should have the same structure as [Range]{@link google.api.Range}
  *
  * @property {Object} bucketOptions
  *   Defines the histogram bucket boundaries. If the distribution does not
  *   contain a histogram, then omit this field.
  *
- *   This object should have the same structure as [BucketOptions]{@link
- * google.api.BucketOptions}
+ *   This object should have the same structure as [BucketOptions]{@link google.api.BucketOptions}
  *
  * @property {number[]} bucketCounts
  *   The number of values in each bucket of the histogram, as described in
@@ -85,8 +83,7 @@
  * @property {Object[]} exemplars
  *   Must be in increasing order of `value` field.
  *
- *   This object should have the same structure as [Exemplar]{@link
- * google.api.Exemplar}
+ *   This object should have the same structure as [Exemplar]{@link google.api.Exemplar}
  *
  * @typedef Distribution
  * @memberof google.api
@@ -109,7 +106,7 @@ const Distribution = {
    * @see [google.api.Distribution.Range definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/distribution.proto}
    */
   Range: {
-      // This is for documentation. Actual contents will be loaded by gRPC.
+    // This is for documentation. Actual contents will be loaded by gRPC.
   },
 
   /**
@@ -132,20 +129,17 @@ const Distribution = {
    * @property {Object} linearBuckets
    *   The linear bucket.
    *
-   *   This object should have the same structure as [Linear]{@link
-   * google.api.Linear}
+   *   This object should have the same structure as [Linear]{@link google.api.Linear}
    *
    * @property {Object} exponentialBuckets
    *   The exponential buckets.
    *
-   *   This object should have the same structure as [Exponential]{@link
-   * google.api.Exponential}
+   *   This object should have the same structure as [Exponential]{@link google.api.Exponential}
    *
    * @property {Object} explicitBuckets
    *   The explicit buckets.
    *
-   *   This object should have the same structure as [Explicit]{@link
-   * google.api.Explicit}
+   *   This object should have the same structure as [Explicit]{@link google.api.Explicit}
    *
    * @typedef BucketOptions
    * @memberof google.api
@@ -179,7 +173,7 @@ const Distribution = {
      * @see [google.api.Distribution.BucketOptions.Linear definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/distribution.proto}
      */
     Linear: {
-        // This is for documentation. Actual contents will be loaded by gRPC.
+      // This is for documentation. Actual contents will be loaded by gRPC.
     },
 
     /**
@@ -207,7 +201,7 @@ const Distribution = {
      * @see [google.api.Distribution.BucketOptions.Exponential definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/distribution.proto}
      */
     Exponential: {
-        // This is for documentation. Actual contents will be loaded by gRPC.
+      // This is for documentation. Actual contents will be loaded by gRPC.
     },
 
     /**
@@ -231,7 +225,7 @@ const Distribution = {
      * @see [google.api.Distribution.BucketOptions.Explicit definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/distribution.proto}
      */
     Explicit: {
-        // This is for documentation. Actual contents will be loaded by gRPC.
+      // This is for documentation. Actual contents will be loaded by gRPC.
     }
   },
 
@@ -249,8 +243,7 @@ const Distribution = {
    * @property {Object} timestamp
    *   The observation (sampling) time of the above value.
    *
-   *   This object should have the same structure as [Timestamp]{@link
-   * google.protobuf.Timestamp}
+   *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
    *
    * @property {Object[]} attachments
    *   Contextual information about the example value. Examples are:
@@ -265,14 +258,13 @@ const Distribution = {
    *   There may be only a single attachment of any given message type in a
    *   single exemplar, and this is enforced by the system.
    *
-   *   This object should have the same structure as [Any]{@link
-   * google.protobuf.Any}
+   *   This object should have the same structure as [Any]{@link google.protobuf.Any}
    *
    * @typedef Exemplar
    * @memberof google.api
    * @see [google.api.Distribution.Exemplar definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/distribution.proto}
    */
   Exemplar: {
-      // This is for documentation. Actual contents will be loaded by gRPC.
+    // This is for documentation. Actual contents will be loaded by gRPC.
   }
 };

--- a/src/v2/doc/google/api/doc_label.js
+++ b/src/v2/doc/google/api/doc_label.js
@@ -24,8 +24,7 @@
  * @property {number} valueType
  *   The type of data that can be assigned to the label.
  *
- *   The number should be among the values of [ValueType]{@link
- * google.api.ValueType}
+ *   The number should be among the values of [ValueType]{@link google.api.ValueType}
  *
  * @property {string} description
  *   A human-readable description for the label.

--- a/src/v2/doc/google/api/doc_metric.js
+++ b/src/v2/doc/google/api/doc_metric.js
@@ -41,22 +41,19 @@
  *   you can look at latencies for successful responses or just
  *   for responses that failed.
  *
- *   This object should have the same structure as [LabelDescriptor]{@link
- * google.api.LabelDescriptor}
+ *   This object should have the same structure as [LabelDescriptor]{@link google.api.LabelDescriptor}
  *
  * @property {number} metricKind
  *   Whether the metric records instantaneous values, changes to a value, etc.
  *   Some combinations of `metric_kind` and `value_type` might not be supported.
  *
- *   The number should be among the values of [MetricKind]{@link
- * google.api.MetricKind}
+ *   The number should be among the values of [MetricKind]{@link google.api.MetricKind}
  *
  * @property {number} valueType
  *   Whether the measurement is an integer, a floating-point number, etc.
  *   Some combinations of `metric_kind` and `value_type` might not be supported.
  *
- *   The number should be among the values of [ValueType]{@link
- * google.api.ValueType}
+ *   The number should be among the values of [ValueType]{@link google.api.ValueType}
  *
  * @property {string} unit
  *   The unit in which the metric value is reported. It is only applicable
@@ -137,8 +134,7 @@
  * @property {Object} metadata
  *   Optional. Metadata which can be used to guide usage of the metric.
  *
- *   This object should have the same structure as
- * [MetricDescriptorMetadata]{@link google.api.MetricDescriptorMetadata}
+ *   This object should have the same structure as [MetricDescriptorMetadata]{@link google.api.MetricDescriptorMetadata}
  *
  * @typedef MetricDescriptor
  * @memberof google.api
@@ -153,8 +149,7 @@ const MetricDescriptor = {
    * @property {number} launchStage
    *   The launch stage of the metric definition.
    *
-   *   The number should be among the values of [LaunchStage]{@link
-   * google.api.LaunchStage}
+   *   The number should be among the values of [LaunchStage]{@link google.api.LaunchStage}
    *
    * @property {Object} samplePeriod
    *   The sampling period of metric data points. For metrics which are written
@@ -162,23 +157,21 @@ const MetricDescriptor = {
    *   excluding data loss due to errors. Metrics with a higher granularity have
    *   a smaller sampling period.
    *
-   *   This object should have the same structure as [Duration]{@link
-   * google.protobuf.Duration}
+   *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
    *
    * @property {Object} ingestDelay
    *   The delay of data points caused by ingestion. Data points older than this
    *   age are guaranteed to be ingested and available to be read, excluding
    *   data loss due to errors.
    *
-   *   This object should have the same structure as [Duration]{@link
-   * google.protobuf.Duration}
+   *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
    *
    * @typedef MetricDescriptorMetadata
    * @memberof google.api
    * @see [google.api.MetricDescriptor.MetricDescriptorMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/metric.proto}
    */
   MetricDescriptorMetadata: {
-      // This is for documentation. Actual contents will be loaded by gRPC.
+    // This is for documentation. Actual contents will be loaded by gRPC.
   },
 
   /**
@@ -278,5 +271,5 @@ const MetricDescriptor = {
  * @see [google.api.Metric definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/metric.proto}
  */
 const Metric = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/api/doc_monitored_resource.js
+++ b/src/v2/doc/google/api/doc_monitored_resource.js
@@ -54,15 +54,14 @@
  *   resource type. For example, an individual Google Cloud SQL database is
  *   identified by values for the labels `"database_id"` and `"zone"`.
  *
- *   This object should have the same structure as [LabelDescriptor]{@link
- * google.api.LabelDescriptor}
+ *   This object should have the same structure as [LabelDescriptor]{@link google.api.LabelDescriptor}
  *
  * @typedef MonitoredResourceDescriptor
  * @memberof google.api
  * @see [google.api.MonitoredResourceDescriptor definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto}
  */
 const MonitoredResourceDescriptor = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -95,7 +94,7 @@ const MonitoredResourceDescriptor = {
  * @see [google.api.MonitoredResource definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto}
  */
 const MonitoredResource = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -118,8 +117,7 @@ const MonitoredResource = {
  *         "security_group": ["a", "b", "c"],
  *         "spot_instance": false }
  *
- *   This object should have the same structure as [Struct]{@link
- * google.protobuf.Struct}
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object.<string, string>} userLabels
  *   Output only. A map of user-defined metadata labels.
@@ -129,5 +127,5 @@ const MonitoredResource = {
  * @see [google.api.MonitoredResourceMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto}
  */
 const MonitoredResourceMetadata = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/logging/type/doc_http_request.js
+++ b/src/v2/doc/google/logging/type/doc_http_request.js
@@ -42,8 +42,7 @@
  *
  * @property {string} userAgent
  *   The user agent sent by the client. Example:
- *   `"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET
- * CLR 1.0.3705)"`.
+ *   `"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET CLR 1.0.3705)"`.
  *
  * @property {string} remoteIp
  *   The IP address (IPv4 or IPv6) of the client that issued the HTTP
@@ -55,15 +54,13 @@
  *
  * @property {string} referer
  *   The referer URL of the request, as defined in
- *   [HTTP/1.1 Header Field
- * Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
+ *   [HTTP/1.1 Header Field Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
  *
  * @property {Object} latency
  *   The request processing latency on the server, from the time the request was
  *   received until the response was sent.
  *
- *   This object should have the same structure as [Duration]{@link
- * google.protobuf.Duration}
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
  *
  * @property {boolean} cacheLookup
  *   Whether or not a cache lookup was attempted.
@@ -89,5 +86,5 @@
  * @see [google.logging.type.HttpRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/type/http_request.proto}
  */
 const HttpRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/logging/v2/doc_log_entry.js
+++ b/src/v2/doc/google/logging/v2/doc_log_entry.js
@@ -48,16 +48,14 @@
  *   associated with the monitored resource designating the particular
  *   database that reported the error.
  *
- *   This object should have the same structure as [MonitoredResource]{@link
- * google.api.MonitoredResource}
+ *   This object should have the same structure as [MonitoredResource]{@link google.api.MonitoredResource}
  *
  * @property {Object} protoPayload
  *   The log entry payload, represented as a protocol buffer.  Some
  *   Google Cloud Platform services use this field for their log
  *   entry payloads.
  *
- *   This object should have the same structure as [Any]{@link
- * google.protobuf.Any}
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
  *
  * @property {string} textPayload
  *   The log entry payload, represented as a Unicode string (UTF-8).
@@ -66,8 +64,7 @@
  *   The log entry payload, represented as a structure that is
  *   expressed as a JSON object.
  *
- *   This object should have the same structure as [Struct]{@link
- * google.protobuf.Struct}
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object} timestamp
  *   Optional. The time the event described by the log entry occurred.
@@ -78,27 +75,24 @@
  *   seconds might be omitted when the timestamp is displayed.
  *
  *   Incoming log entries should have timestamps that are no more than
- *   the [logs retention period](https://cloud.google.com/logging/quotas) in the
- * past, and no more than 24 hours in the future. Log entries outside those time
+ *   the [logs retention period](https://cloud.google.com/logging/quotas) in the past,
+ *   and no more than 24 hours in the future. Log entries outside those time
  *   boundaries will not be available when calling `entries.list`, but
  *   those log entries can still be exported with
  *   [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
  *
- *   This object should have the same structure as [Timestamp]{@link
- * google.protobuf.Timestamp}
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {Object} receiveTimestamp
  *   Output only. The time the log entry was received by Logging.
  *
- *   This object should have the same structure as [Timestamp]{@link
- * google.protobuf.Timestamp}
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {number} severity
  *   Optional. The severity of the log entry. The default value is
  *   `LogSeverity.DEFAULT`.
  *
- *   The number should be among the values of [LogSeverity]{@link
- * google.logging.type.LogSeverity}
+ *   The number should be among the values of [LogSeverity]{@link google.logging.type.LogSeverity}
  *
  * @property {string} insertId
  *   Optional. A unique identifier for the log entry. If you provide a value,
@@ -112,8 +106,7 @@
  *   Optional. Information about the HTTP request associated with this
  *   log entry, if applicable.
  *
- *   This object should have the same structure as [HttpRequest]{@link
- * google.logging.type.HttpRequest}
+ *   This object should have the same structure as [HttpRequest]{@link google.logging.type.HttpRequest}
  *
  * @property {Object.<string, string>} labels
  *   Optional. A set of user-defined (key, value) data that provides additional
@@ -124,15 +117,13 @@
  *   Only `k8s_container`, `k8s_pod`, and `k8s_node` MonitoredResources have
  *   this field populated.
  *
- *   This object should have the same structure as
- * [MonitoredResourceMetadata]{@link google.api.MonitoredResourceMetadata}
+ *   This object should have the same structure as [MonitoredResourceMetadata]{@link google.api.MonitoredResourceMetadata}
  *
  * @property {Object} operation
  *   Optional. Information about an operation associated with the log entry, if
  *   applicable.
  *
- *   This object should have the same structure as [LogEntryOperation]{@link
- * google.logging.v2.LogEntryOperation}
+ *   This object should have the same structure as [LogEntryOperation]{@link google.logging.v2.LogEntryOperation}
  *
  * @property {string} trace
  *   Optional. Resource name of the trace associated with the log entry, if any.
@@ -158,15 +149,14 @@
  *   Optional. Source code location information associated with the log entry,
  *   if any.
  *
- *   This object should have the same structure as
- * [LogEntrySourceLocation]{@link google.logging.v2.LogEntrySourceLocation}
+ *   This object should have the same structure as [LogEntrySourceLocation]{@link google.logging.v2.LogEntrySourceLocation}
  *
  * @typedef LogEntry
  * @memberof google.logging.v2
  * @see [google.logging.v2.LogEntry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto}
  */
 const LogEntry = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -193,7 +183,7 @@ const LogEntry = {
  * @see [google.logging.v2.LogEntryOperation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto}
  */
 const LogEntryOperation = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -221,5 +211,5 @@ const LogEntryOperation = {
  * @see [google.logging.v2.LogEntrySourceLocation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto}
  */
 const LogEntrySourceLocation = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/logging/v2/doc_logging.js
+++ b/src/v2/doc/google/logging/v2/doc_logging.js
@@ -37,7 +37,7 @@
  * @see [google.logging.v2.DeleteLogRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const DeleteLogRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -72,8 +72,7 @@ const DeleteLogRequest = {
  *
  *   See LogEntry.
  *
- *   This object should have the same structure as [MonitoredResource]{@link
- * google.api.MonitoredResource}
+ *   This object should have the same structure as [MonitoredResource]{@link google.api.MonitoredResource}
  *
  * @property {Object.<string, string>} labels
  *   Optional. Default labels that are added to the `labels` field of all log
@@ -96,18 +95,17 @@ const DeleteLogRequest = {
  *   the entries later in the list. See the `entries.list` method.
  *
  *   Log entries with timestamps that are more than the
- *   [logs retention period](https://cloud.google.com/logging/quota-policy) in
- * the past or more than 24 hours in the future will not be available when
- * calling `entries.list`. However, those log entries can still be exported with
+ *   [logs retention period](https://cloud.google.com/logging/quota-policy) in the past or more than
+ *   24 hours in the future will not be available when calling `entries.list`.
+ *   However, those log entries can still be exported with
  *   [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
  *
  *   To improve throughput and to avoid exceeding the
- *   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
- * `entries.write`, you should try to include several log entries in this list,
+ *   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to `entries.write`,
+ *   you should try to include several log entries in this list,
  *   rather than calling this method for each individual log entry.
  *
- *   This object should have the same structure as [LogEntry]{@link
- * google.logging.v2.LogEntry}
+ *   This object should have the same structure as [LogEntry]{@link google.logging.v2.LogEntry}
  *
  * @property {boolean} partialSuccess
  *   Optional. Whether valid entries should be written even if some other
@@ -126,7 +124,7 @@ const DeleteLogRequest = {
  * @see [google.logging.v2.WriteLogEntriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const WriteLogEntriesRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -137,7 +135,7 @@ const WriteLogEntriesRequest = {
  * @see [google.logging.v2.WriteLogEntriesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const WriteLogEntriesResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -156,7 +154,7 @@ const WriteLogEntriesResponse = {
  * @see [google.logging.v2.WriteLogEntriesPartialErrors definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const WriteLogEntriesPartialErrors = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -182,11 +180,12 @@ const WriteLogEntriesPartialErrors = {
  *
  * @property {string} filter
  *   Optional. A filter that chooses which log entries to return.  See [Advanced
- *   Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
- * Only log entries that match the filter are returned.  An empty filter matches
- * all log entries in the resources listed in `resource_names`. Referencing a
- * parent resource that is not listed in `resource_names` will cause the filter
- * to return no results. The maximum length of the filter is 20000 characters.
+ *   Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).  Only log entries that
+ *   match the filter are returned.  An empty filter matches all log entries in
+ *   the resources listed in `resource_names`. Referencing a parent resource
+ *   that is not listed in `resource_names` will cause the filter to return no
+ *   results.
+ *   The maximum length of the filter is 20000 characters.
  *
  * @property {string} orderBy
  *   Optional. How the results should be sorted.  Presently, the only permitted
@@ -212,7 +211,7 @@ const WriteLogEntriesPartialErrors = {
  * @see [google.logging.v2.ListLogEntriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListLogEntriesRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -223,8 +222,7 @@ const ListLogEntriesRequest = {
  *   returned, indicating that more entries may exist.  See `nextPageToken` for
  *   more information.
  *
- *   This object should have the same structure as [LogEntry]{@link
- * google.logging.v2.LogEntry}
+ *   This object should have the same structure as [LogEntry]{@link google.logging.v2.LogEntry}
  *
  * @property {string} nextPageToken
  *   If there might be more results than those appearing in this response, then
@@ -243,7 +241,7 @@ const ListLogEntriesRequest = {
  * @see [google.logging.v2.ListLogEntriesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListLogEntriesResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -265,7 +263,7 @@ const ListLogEntriesResponse = {
  * @see [google.logging.v2.ListMonitoredResourceDescriptorsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListMonitoredResourceDescriptorsRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -274,8 +272,7 @@ const ListMonitoredResourceDescriptorsRequest = {
  * @property {Object[]} resourceDescriptors
  *   A list of resource descriptors.
  *
- *   This object should have the same structure as
- * [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}
+ *   This object should have the same structure as [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}
  *
  * @property {string} nextPageToken
  *   If there might be more results than those appearing in this response, then
@@ -287,7 +284,7 @@ const ListMonitoredResourceDescriptorsRequest = {
  * @see [google.logging.v2.ListMonitoredResourceDescriptorsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListMonitoredResourceDescriptorsResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -317,7 +314,7 @@ const ListMonitoredResourceDescriptorsResponse = {
  * @see [google.logging.v2.ListLogsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListLogsRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -338,5 +335,5 @@ const ListLogsRequest = {
  * @see [google.logging.v2.ListLogsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto}
  */
 const ListLogsResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/logging/v2/doc_logging_config.js
+++ b/src/v2/doc/google/logging/v2/doc_logging_config.js
@@ -39,15 +39,13 @@
  *   The sink's `writer_identity`, set when the sink is created, must
  *   have permission to write to the destination or else the log
  *   entries are not exported.  For more information, see
- *   [Exporting Logs With
- * Sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
+ *   [Exporting Logs With Sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
  *
  * @property {string} filter
  *   Optional.
- *   An [advanced logs
- * filter](https://cloud.google.com/logging/docs/view/advanced_filters).  The
- * only exported log entries are those that are in the resource owning the sink
- * and that match the filter.  For example:
+ *   An [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters).  The only
+ *   exported log entries are those that are in the resource owning the sink and
+ *   that match the filter.  For example:
  *
  *       logName="projects/[PROJECT_ID]/logs/[LOG_ID]" AND severity>=ERROR
  *
@@ -55,8 +53,7 @@
  *   Deprecated. The log entry format to use for this sink's exported log
  *   entries.  The v2 format is used by default and cannot be changed.
  *
- *   The number should be among the values of [VersionFormat]{@link
- * google.logging.v2.VersionFormat}
+ *   The number should be among the values of [VersionFormat]{@link google.logging.v2.VersionFormat}
  *
  * @property {string} writerIdentity
  *   Output only. An IAM identity&mdash;a service account or group&mdash;under
@@ -92,14 +89,12 @@
  * @property {Object} startTime
  *   Deprecated. This field is ignored when creating or updating sinks.
  *
- *   This object should have the same structure as [Timestamp]{@link
- * google.protobuf.Timestamp}
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {Object} endTime
  *   Deprecated. This field is ignored when creating or updating sinks.
  *
- *   This object should have the same structure as [Timestamp]{@link
- * google.protobuf.Timestamp}
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @typedef LogSink
  * @memberof google.logging.v2
@@ -162,7 +157,7 @@ const LogSink = {
  * @see [google.logging.v2.ListSinksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const ListSinksRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -171,8 +166,7 @@ const ListSinksRequest = {
  * @property {Object[]} sinks
  *   A list of sinks.
  *
- *   This object should have the same structure as [LogSink]{@link
- * google.logging.v2.LogSink}
+ *   This object should have the same structure as [LogSink]{@link google.logging.v2.LogSink}
  *
  * @property {string} nextPageToken
  *   If there might be more results than appear in this response, then
@@ -184,7 +178,7 @@ const ListSinksRequest = {
  * @see [google.logging.v2.ListSinksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const ListSinksResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -205,7 +199,7 @@ const ListSinksResponse = {
  * @see [google.logging.v2.GetSinkRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const GetSinkRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -225,8 +219,7 @@ const GetSinkRequest = {
  *   Required. The new sink, whose `name` parameter is a sink identifier that
  *   is not already in use.
  *
- *   This object should have the same structure as [LogSink]{@link
- * google.logging.v2.LogSink}
+ *   This object should have the same structure as [LogSink]{@link google.logging.v2.LogSink}
  *
  * @property {boolean} uniqueWriterIdentity
  *   Optional. Determines the kind of IAM identity returned as `writer_identity`
@@ -246,7 +239,7 @@ const GetSinkRequest = {
  * @see [google.logging.v2.CreateSinkRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const CreateSinkRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -267,8 +260,7 @@ const CreateSinkRequest = {
  *   Required. The updated sink, whose name is the same identifier that appears
  *   as part of `sink_name`.
  *
- *   This object should have the same structure as [LogSink]{@link
- * google.logging.v2.LogSink}
+ *   This object should have the same structure as [LogSink]{@link google.logging.v2.LogSink}
  *
  * @property {boolean} uniqueWriterIdentity
  *   Optional. See
@@ -300,15 +292,14 @@ const CreateSinkRequest = {
  *
  *   Example: `updateMask=filter`.
  *
- *   This object should have the same structure as [FieldMask]{@link
- * google.protobuf.FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  *
  * @typedef UpdateSinkRequest
  * @memberof google.logging.v2
  * @see [google.logging.v2.UpdateSinkRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const UpdateSinkRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -330,7 +321,7 @@ const UpdateSinkRequest = {
  * @see [google.logging.v2.DeleteSinkRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const DeleteSinkRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -351,10 +342,9 @@ const DeleteSinkRequest = {
  *
  * @property {string} filter
  *   Required.
- *   An [advanced logs
- * filter](https://cloud.google.com/logging/docs/view/advanced_filters) that
- * matches the log entries to be excluded. By using the [sample
- * function](https://cloud.google.com/logging/docs/view/advanced_filters#sample),
+ *   An [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters)
+ *   that matches the log entries to be excluded. By using the
+ *   [sample function](https://cloud.google.com/logging/docs/view/advanced_filters#sample),
  *   you can exclude less than 100% of the matching log entries.
  *   For example, the following filter matches 99% of low-severity log
  *   entries from load balancers:
@@ -372,7 +362,7 @@ const DeleteSinkRequest = {
  * @see [google.logging.v2.LogExclusion definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const LogExclusion = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -402,7 +392,7 @@ const LogExclusion = {
  * @see [google.logging.v2.ListExclusionsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const ListExclusionsRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -411,8 +401,7 @@ const ListExclusionsRequest = {
  * @property {Object[]} exclusions
  *   A list of exclusions.
  *
- *   This object should have the same structure as [LogExclusion]{@link
- * google.logging.v2.LogExclusion}
+ *   This object should have the same structure as [LogExclusion]{@link google.logging.v2.LogExclusion}
  *
  * @property {string} nextPageToken
  *   If there might be more results than appear in this response, then
@@ -424,7 +413,7 @@ const ListExclusionsRequest = {
  * @see [google.logging.v2.ListExclusionsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const ListExclusionsResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -445,7 +434,7 @@ const ListExclusionsResponse = {
  * @see [google.logging.v2.GetExclusionRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const GetExclusionRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -465,15 +454,14 @@ const GetExclusionRequest = {
  *   Required. The new exclusion, whose `name` parameter is an exclusion name
  *   that is not already used in the parent resource.
  *
- *   This object should have the same structure as [LogExclusion]{@link
- * google.logging.v2.LogExclusion}
+ *   This object should have the same structure as [LogExclusion]{@link google.logging.v2.LogExclusion}
  *
  * @typedef CreateExclusionRequest
  * @memberof google.logging.v2
  * @see [google.logging.v2.CreateExclusionRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const CreateExclusionRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -493,8 +481,7 @@ const CreateExclusionRequest = {
  *   Required. New values for the existing exclusion. Only the fields specified
  *   in `update_mask` are relevant.
  *
- *   This object should have the same structure as [LogExclusion]{@link
- * google.logging.v2.LogExclusion}
+ *   This object should have the same structure as [LogExclusion]{@link google.logging.v2.LogExclusion}
  *
  * @property {Object} updateMask
  *   Required. A nonempty list of fields to change in the existing exclusion.
@@ -505,15 +492,14 @@ const CreateExclusionRequest = {
  *   For example, to change the filter and description of an exclusion,
  *   specify an `update_mask` of `"filter,description"`.
  *
- *   This object should have the same structure as [FieldMask]{@link
- * google.protobuf.FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  *
  * @typedef UpdateExclusionRequest
  * @memberof google.logging.v2
  * @see [google.logging.v2.UpdateExclusionRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const UpdateExclusionRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -534,5 +520,5 @@ const UpdateExclusionRequest = {
  * @see [google.logging.v2.DeleteExclusionRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto}
  */
 const DeleteExclusionRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/logging/v2/doc_logging_metrics.js
+++ b/src/v2/doc/google/logging/v2/doc_logging_metrics.js
@@ -45,9 +45,9 @@
  *   Optional. A description of this metric, which is used in documentation.
  *
  * @property {string} filter
- *   Required. An [advanced logs
- * filter](https://cloud.google.com/logging/docs/view/advanced_filters) which is
- * used to match log entries. Example:
+ *   Required. An [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters)
+ *   which is used to match log entries.
+ *   Example:
  *
  *       "resource.type=gae_app AND severity>=ERROR"
  *
@@ -76,8 +76,7 @@
  *   `metric_descriptor`, but existing labels cannot be modified except for
  *   their description.
  *
- *   This object should have the same structure as [MetricDescriptor]{@link
- * google.api.MetricDescriptor}
+ *   This object should have the same structure as [MetricDescriptor]{@link google.api.MetricDescriptor}
  *
  * @property {string} valueExtractor
  *   Optional. A `value_extractor` is required when using a distribution
@@ -121,15 +120,13 @@
  *   using a DISTRIBUTION value type and it describes the bucket boundaries
  *   used to create a histogram of the extracted values.
  *
- *   This object should have the same structure as [BucketOptions]{@link
- * google.api.BucketOptions}
+ *   This object should have the same structure as [BucketOptions]{@link google.api.BucketOptions}
  *
  * @property {number} version
  *   Deprecated. The API version that created or updated this metric.
  *   The v2 format is used by default and cannot be changed.
  *
- *   The number should be among the values of [ApiVersion]{@link
- * google.logging.v2.ApiVersion}
+ *   The number should be among the values of [ApiVersion]{@link google.logging.v2.ApiVersion}
  *
  * @typedef LogMetric
  * @memberof google.logging.v2
@@ -182,7 +179,7 @@ const LogMetric = {
  * @see [google.logging.v2.ListLogMetricsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const ListLogMetricsRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -191,8 +188,7 @@ const ListLogMetricsRequest = {
  * @property {Object[]} metrics
  *   A list of logs-based metrics.
  *
- *   This object should have the same structure as [LogMetric]{@link
- * google.logging.v2.LogMetric}
+ *   This object should have the same structure as [LogMetric]{@link google.logging.v2.LogMetric}
  *
  * @property {string} nextPageToken
  *   If there might be more results than appear in this response, then
@@ -204,7 +200,7 @@ const ListLogMetricsRequest = {
  * @see [google.logging.v2.ListLogMetricsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const ListLogMetricsResponse = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -220,7 +216,7 @@ const ListLogMetricsResponse = {
  * @see [google.logging.v2.GetLogMetricRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const GetLogMetricRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -237,15 +233,14 @@ const GetLogMetricRequest = {
  *   The new logs-based metric, which must not have an identifier that
  *   already exists.
  *
- *   This object should have the same structure as [LogMetric]{@link
- * google.logging.v2.LogMetric}
+ *   This object should have the same structure as [LogMetric]{@link google.logging.v2.LogMetric}
  *
  * @typedef CreateLogMetricRequest
  * @memberof google.logging.v2
  * @see [google.logging.v2.CreateLogMetricRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const CreateLogMetricRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -263,15 +258,14 @@ const CreateLogMetricRequest = {
  * @property {Object} metric
  *   The updated metric.
  *
- *   This object should have the same structure as [LogMetric]{@link
- * google.logging.v2.LogMetric}
+ *   This object should have the same structure as [LogMetric]{@link google.logging.v2.LogMetric}
  *
  * @typedef UpdateLogMetricRequest
  * @memberof google.logging.v2
  * @see [google.logging.v2.UpdateLogMetricRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const UpdateLogMetricRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -287,5 +281,5 @@ const UpdateLogMetricRequest = {
  * @see [google.logging.v2.DeleteLogMetricRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto}
  */
 const DeleteLogMetricRequest = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/protobuf/doc_any.js
+++ b/src/v2/doc/google/protobuf/doc_any.js
@@ -132,5 +132,5 @@
  * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
  */
 const Any = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/protobuf/doc_duration.js
+++ b/src/v2/doc/google/protobuf/doc_duration.js
@@ -93,5 +93,5 @@
  * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
  */
 const Duration = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/protobuf/doc_empty.js
+++ b/src/v2/doc/google/protobuf/doc_empty.js
@@ -30,5 +30,5 @@
  * @see [google.protobuf.Empty definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/empty.proto}
  */
 const Empty = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/protobuf/doc_field_mask.js
+++ b/src/v2/doc/google/protobuf/doc_field_mask.js
@@ -232,5 +232,5 @@
  * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
  */
 const FieldMask = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/doc/google/protobuf/doc_struct.js
+++ b/src/v2/doc/google/protobuf/doc_struct.js
@@ -33,7 +33,7 @@
  * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 const Struct = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -47,8 +47,7 @@ const Struct = {
  * @property {number} nullValue
  *   Represents a null value.
  *
- *   The number should be among the values of [NullValue]{@link
- * google.protobuf.NullValue}
+ *   The number should be among the values of [NullValue]{@link google.protobuf.NullValue}
  *
  * @property {number} numberValue
  *   Represents a double value.
@@ -62,21 +61,19 @@ const Struct = {
  * @property {Object} structValue
  *   Represents a structured value.
  *
- *   This object should have the same structure as [Struct]{@link
- * google.protobuf.Struct}
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object} listValue
  *   Represents a repeated `Value`.
  *
- *   This object should have the same structure as [ListValue]{@link
- * google.protobuf.ListValue}
+ *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
  *
  * @typedef Value
  * @memberof google.protobuf
  * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 const Value = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**
@@ -87,15 +84,14 @@ const Value = {
  * @property {Object[]} values
  *   Repeated field of dynamically typed values.
  *
- *   This object should have the same structure as [Value]{@link
- * google.protobuf.Value}
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
  *
  * @typedef ListValue
  * @memberof google.protobuf
  * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 const ListValue = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
 /**

--- a/src/v2/doc/google/protobuf/doc_timestamp.js
+++ b/src/v2/doc/google/protobuf/doc_timestamp.js
@@ -26,8 +26,7 @@
  * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
  * By restricting to that range, we ensure that we can convert to
  * and from  RFC 3339 date strings.
- * See
- * [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+ * See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
  *
  * # Examples
  *
@@ -88,13 +87,11 @@
  * 01:30 UTC on January 15, 2017.
  *
  * In JavaScript, one can convert a Date object to this format using the
- * standard
- * [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+ * standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
  * method. In Python, a standard `datetime.datetime` object can be converted
- * to this format using
- * [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
- * the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
- * the Joda Time's [`ISODateTimeFormat.dateTime()`](https://cloud.google.com
+ * to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+ * with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+ * can use the Joda Time's [`ISODateTimeFormat.dateTime()`](https://cloud.google.com
  * http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
  * ) to obtain a formatter capable of generating timestamps in this format.
  *
@@ -114,5 +111,5 @@
  * @see [google.protobuf.Timestamp definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto}
  */
 const Timestamp = {
-    // This is for documentation. Actual contents will be loaded by gRPC.
+  // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v2/logging_service_v2_client.js
+++ b/src/v2/logging_service_v2_client.js
@@ -49,10 +49,8 @@ class LoggingServiceV2Client {
    *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
    *     the environment variable GCLOUD_PROJECT for your project ID. If your
    *     app is running in an environment which supports
-   *     {@link
-   * https://developers.google.com/identity/protocols/application-default-credentials
-   * Application Default Credentials}, your project ID will be detected
-   * automatically.
+   *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+   *     your project ID will be detected automatically.
    * @param {function} [options.promise] - Custom promise module to use instead
    *     of native Promises.
    * @param {string} [options.servicePath] - The domain name of the
@@ -63,12 +61,13 @@ class LoggingServiceV2Client {
 
     // Ensure that options include the service address and port.
     opts = Object.assign(
-        {
-          clientConfig: {},
-          port: this.constructor.port,
-          servicePath: this.constructor.servicePath,
-        },
-        opts);
+      {
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      },
+      opts
+    );
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
@@ -91,56 +90,74 @@ class LoggingServiceV2Client {
 
     // Load the applicable protos.
     const protos = merge(
-        {},
-        gaxGrpc.loadProto(
-            path.join(__dirname, '..', '..', 'protos'),
-            'google/logging/v2/logging.proto'));
+      {},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'google/logging/v2/logging.proto'
+      )
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      logPathTemplate: new gax.PathTemplate('projects/{project}/logs/{log}'),
-      projectPathTemplate: new gax.PathTemplate('projects/{project}'),
+      logPathTemplate: new gax.PathTemplate(
+        'projects/{project}/logs/{log}'
+      ),
+      projectPathTemplate: new gax.PathTemplate(
+        'projects/{project}'
+      ),
     };
 
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listLogEntries:
-          new gax.PageDescriptor('pageToken', 'nextPageToken', 'entries'),
+      listLogEntries: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'entries'
+      ),
       listMonitoredResourceDescriptors: new gax.PageDescriptor(
-          'pageToken', 'nextPageToken', 'resourceDescriptors'),
-      listLogs:
-          new gax.PageDescriptor('pageToken', 'nextPageToken', 'logNames'),
+        'pageToken',
+        'nextPageToken',
+        'resourceDescriptors'
+      ),
+      listLogs: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'logNames'
+      ),
     };
     let protoFilesRoot = new gax.GoogleProtoFilesRoot();
     protoFilesRoot = protobuf.loadSync(
-        path.join(
-            __dirname, '..', '..', 'protos', 'google/logging/v2/logging.proto'),
-        protoFilesRoot);
+      path.join(__dirname, '..', '..', 'protos', 'google/logging/v2/logging.proto'),
+      protoFilesRoot
+    );
 
 
     // Some methods on this API support automatically batching
     // requests; denote this.
     this._descriptors.batching = {
       writeLogEntries: new gax.BundleDescriptor(
-          'entries',
-          [
-            'logName',
-            'resource',
-            'labels',
-          ],
-          null,
-          gax.createByteLengthFunction(
-              protoFilesRoot.lookup('google.logging.v2.LogEntry'))),
+        'entries',
+        [
+          'logName',
+          'resource',
+          'labels',
+        ],
+        null,
+        gax.createByteLengthFunction(protoFilesRoot.lookup('google.logging.v2.LogEntry'))
+      ),
     };
 
     // Put together the default options sent with requests.
     const defaults = gaxGrpc.constructSettings(
-        'google.logging.v2.LoggingServiceV2', gapicConfig, opts.clientConfig,
-        {'x-goog-api-client': clientHeader.join(' ')});
+      'google.logging.v2.LoggingServiceV2',
+      gapicConfig,
+      opts.clientConfig,
+      {'x-goog-api-client': clientHeader.join(' ')}
+    );
 
     // Set up a dictionary of "inner API calls"; the core implementation
     // of calling the API is handled in `google-gax`, with this code
@@ -149,8 +166,10 @@ class LoggingServiceV2Client {
 
     // Put together the "service stub" for
     // google.logging.v2.LoggingServiceV2.
-    const loggingServiceV2Stub =
-        gaxGrpc.createStub(protos.google.logging.v2.LoggingServiceV2, opts);
+    const loggingServiceV2Stub = gaxGrpc.createStub(
+      protos.google.logging.v2.LoggingServiceV2,
+      opts
+    );
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -163,13 +182,16 @@ class LoggingServiceV2Client {
     ];
     for (const methodName of loggingServiceV2StubMethods) {
       this._innerApiCalls[methodName] = gax.createApiCall(
-          loggingServiceV2Stub.then(stub => function() {
-            const args = Array.prototype.slice.call(arguments, 0);
-            return stub[methodName].apply(stub, args);
-          }),
-          defaults[methodName],
-          this._descriptors.page[methodName] ||
-              this._descriptors.batching[methodName]);
+        loggingServiceV2Stub.then(
+          stub =>
+            function() {
+              const args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }
+        ),
+        defaults[methodName],
+        this._descriptors.page[methodName] || this._descriptors.batching[methodName]
+      );
     }
   }
 
@@ -232,21 +254,16 @@ class LoggingServiceV2Client {
    *
    *   `[LOG_ID]` must be URL-encoded. For example,
    *   `"projects/my-project-id/logs/syslog"`,
-   *
-   `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+   *   `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
    *   For more information about log names, see
    *   LogEntry.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error)} [callback]
    *   The function which will be called with the result of the API call.
    * @returns {Promise} - The promise which resolves when API call finishes.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -291,28 +308,23 @@ class LoggingServiceV2Client {
    *   LogEntry type.
    *
    *   If the `timestamp` or `insert_id` fields are missing in log entries, then
-   *   this method supplies the current time or a unique identifier,
-   respectively.
-   *   The supplied values are chosen so that, among the log entries that did
-   not
+   *   this method supplies the current time or a unique identifier, respectively.
+   *   The supplied values are chosen so that, among the log entries that did not
    *   supply their own values, the entries earlier in the list will sort before
    *   the entries later in the list. See the `entries.list` method.
    *
    *   Log entries with timestamps that are more than the
-   *   [logs retention period](https://cloud.google.com/logging/quota-policy) in
-   the past or more than
+   *   [logs retention period](https://cloud.google.com/logging/quota-policy) in the past or more than
    *   24 hours in the future will not be available when calling `entries.list`.
    *   However, those log entries can still be exported with
-   * [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
+   *   [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
    *
    *   To improve throughput and to avoid exceeding the
-   *   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
-   `entries.write`,
+   *   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to `entries.write`,
    *   you should try to include several log entries in this list,
    *   rather than calling this method for each individual log entry.
    *
-   *   This object should have the same structure as [LogEntry]{@link
-   google.logging.v2.LogEntry}
+   *   This object should have the same structure as [LogEntry]{@link google.logging.v2.LogEntry}
    * @param {string} [request.logName]
    *   Optional. A default log resource name that is assigned to all log entries
    *   in `entries` that do not specify a value for `log_name`:
@@ -325,8 +337,7 @@ class LoggingServiceV2Client {
    *   `[LOG_ID]` must be URL-encoded. For example:
    *
    *       "projects/my-project-id/logs/syslog"
-   *
-   "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+   *       "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
    *
    *   The permission <code>logging.logEntries.create</code> is needed on each
    *   project, organization, billing account, or folder that is receiving
@@ -342,12 +353,10 @@ class LoggingServiceV2Client {
    *
    *   See LogEntry.
    *
-   *   This object should have the same structure as [MonitoredResource]{@link
-   google.api.MonitoredResource}
+   *   This object should have the same structure as [MonitoredResource]{@link google.api.MonitoredResource}
    * @param {Object.<string, string>} [request.labels]
    *   Optional. Default labels that are added to the `labels` field of all log
-   *   entries in `entries`. If a log entry already has a label with the same
-   key
+   *   entries in `entries`. If a log entry already has a label with the same key
    *   as a label in this parameter, then the log entry's label is not changed.
    *   See LogEntry.
    * @param {boolean} [request.partialSuccess]
@@ -361,21 +370,15 @@ class LoggingServiceV2Client {
    *   entries won't be persisted nor exported. Useful for checking whether the
    *   logging API endpoints are working properly before sending valuable data.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [WriteLogEntriesResponse]{@link google.logging.v2.WriteLogEntriesResponse}.
+   *   The second parameter to the callback is an object representing [WriteLogEntriesResponse]{@link google.logging.v2.WriteLogEntriesResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [WriteLogEntriesResponse]{@link google.logging.v2.WriteLogEntriesResponse}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [WriteLogEntriesResponse]{@link google.logging.v2.WriteLogEntriesResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -423,31 +426,24 @@ class LoggingServiceV2Client {
    *
    *   Projects listed in the `project_ids` field are added to this list.
    * @param {string[]} [request.projectIds]
-   *   Deprecated. Use `resource_names` instead.  One or more project
-   identifiers
+   *   Deprecated. Use `resource_names` instead.  One or more project identifiers
    *   or project numbers from which to retrieve log entries.  Example:
    *   `"my-project-1A"`. If present, these project identifiers are converted to
    *   resource name format and added to the list of resources in
    *   `resource_names`.
    * @param {string} [request.filter]
-   *   Optional. A filter that chooses which log entries to return.  See
-   [Advanced
-   *   Logs
-   Filters](https://cloud.google.com/logging/docs/view/advanced_filters).  Only
-   log entries that
-   *   match the filter are returned.  An empty filter matches all log entries
-   in
+   *   Optional. A filter that chooses which log entries to return.  See [Advanced
+   *   Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).  Only log entries that
+   *   match the filter are returned.  An empty filter matches all log entries in
    *   the resources listed in `resource_names`. Referencing a parent resource
    *   that is not listed in `resource_names` will cause the filter to return no
    *   results.
    *   The maximum length of the filter is 20000 characters.
    * @param {string} [request.orderBy]
-   *   Optional. How the results should be sorted.  Presently, the only
-   permitted
+   *   Optional. How the results should be sorted.  Presently, the only permitted
    *   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
    *   option returns entries in order of increasing values of
-   *   `LogEntry.timestamp` (oldest first), and the second option returns
-   entries
+   *   `LogEntry.timestamp` (oldest first), and the second option returns entries
    *   in order of decreasing timestamps (newest first).  Entries with equal
    *   timestamps are returned in order of their `insert_id` values.
    * @param {number} [request.pageSize]
@@ -457,40 +453,27 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is Array of [LogEntry]{@link
-   google.logging.v2.LogEntry}.
+   *   The second parameter to the callback is Array of [LogEntry]{@link google.logging.v2.LogEntry}.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListLogEntriesResponse]{@link google.logging.v2.ListLogEntriesResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListLogEntriesResponse]{@link google.logging.v2.ListLogEntriesResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of [LogEntry]{@link
-   google.logging.v2.LogEntry}.
+   *   The first element of the array is Array of [LogEntry]{@link google.logging.v2.LogEntry}.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
-   *   The first element is Array of [LogEntry]{@link
-   google.logging.v2.LogEntry} in a single response.
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [LogEntry]{@link google.logging.v2.LogEntry} in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListLogEntriesResponse]{@link
-   google.logging.v2.ListLogEntriesResponse}.
+   *   an object representing [ListLogEntriesResponse]{@link google.logging.v2.ListLogEntriesResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -554,8 +537,7 @@ class LoggingServiceV2Client {
    * Equivalent to {@link listLogEntries}, but returns a NodeJS Stream object.
    *
    * This fetches the paged responses for {@link listLogEntries} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -577,31 +559,24 @@ class LoggingServiceV2Client {
    *
    *   Projects listed in the `project_ids` field are added to this list.
    * @param {string[]} [request.projectIds]
-   *   Deprecated. Use `resource_names` instead.  One or more project
-   identifiers
+   *   Deprecated. Use `resource_names` instead.  One or more project identifiers
    *   or project numbers from which to retrieve log entries.  Example:
    *   `"my-project-1A"`. If present, these project identifiers are converted to
    *   resource name format and added to the list of resources in
    *   `resource_names`.
    * @param {string} [request.filter]
-   *   Optional. A filter that chooses which log entries to return.  See
-   [Advanced
-   *   Logs
-   Filters](https://cloud.google.com/logging/docs/view/advanced_filters).  Only
-   log entries that
-   *   match the filter are returned.  An empty filter matches all log entries
-   in
+   *   Optional. A filter that chooses which log entries to return.  See [Advanced
+   *   Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).  Only log entries that
+   *   match the filter are returned.  An empty filter matches all log entries in
    *   the resources listed in `resource_names`. Referencing a parent resource
    *   that is not listed in `resource_names` will cause the filter to return no
    *   results.
    *   The maximum length of the filter is 20000 characters.
    * @param {string} [request.orderBy]
-   *   Optional. How the results should be sorted.  Presently, the only
-   permitted
+   *   Optional. How the results should be sorted.  Presently, the only permitted
    *   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
    *   option returns entries in order of increasing values of
-   *   `LogEntry.timestamp` (oldest first), and the second option returns
-   entries
+   *   `LogEntry.timestamp` (oldest first), and the second option returns entries
    *   in order of decreasing timestamps (newest first).  Entries with equal
    *   timestamps are returned in order of their `insert_id` values.
    * @param {number} [request.pageSize]
@@ -611,14 +586,10 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
-   *   An object stream which emits an object representing [LogEntry]{@link
-   google.logging.v2.LogEntry} on 'data' event.
+   *   An object stream which emits an object representing [LogEntry]{@link google.logging.v2.LogEntry} on 'data' event.
    *
    * @example
    *
@@ -640,7 +611,10 @@ class LoggingServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listLogEntries.createStream(
-        this._innerApiCalls.listLogEntries, request, options);
+      this._innerApiCalls.listLogEntries,
+      request,
+      options
+    );
   };
 
   /**
@@ -655,41 +629,27 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is Array of
-   [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}.
+   *   The second parameter to the callback is Array of [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListMonitoredResourceDescriptorsResponse]{@link
-   google.logging.v2.ListMonitoredResourceDescriptorsResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListMonitoredResourceDescriptorsResponse]{@link google.logging.v2.ListMonitoredResourceDescriptorsResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of
-   [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}.
+   *   The first element of the array is Array of [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
-   *   The first element is Array of [MonitoredResourceDescriptor]{@link
-   google.api.MonitoredResourceDescriptor} in a single response.
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor} in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListMonitoredResourceDescriptorsResponse]{@link
-   google.logging.v2.ListMonitoredResourceDescriptorsResponse}.
+   *   an object representing [ListMonitoredResourceDescriptorsResponse]{@link google.logging.v2.ListMonitoredResourceDescriptorsResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -726,8 +686,7 @@ class LoggingServiceV2Client {
    *   }
    *   if (nextRequest) {
    *     // Fetch the next page.
-   *     return client.listMonitoredResourceDescriptors(nextRequest,
-   options).then(callback);
+   *     return client.listMonitoredResourceDescriptors(nextRequest, options).then(callback);
    *   }
    * }
    * client.listMonitoredResourceDescriptors({}, options)
@@ -743,18 +702,14 @@ class LoggingServiceV2Client {
     }
     options = options || {};
 
-    return this._innerApiCalls.listMonitoredResourceDescriptors(
-        request, options, callback);
+    return this._innerApiCalls.listMonitoredResourceDescriptors(request, options, callback);
   }
 
   /**
-   * Equivalent to {@link listMonitoredResourceDescriptors}, but returns a
-   NodeJS Stream object.
+   * Equivalent to {@link listMonitoredResourceDescriptors}, but returns a NodeJS Stream object.
    *
-   * This fetches the paged responses for {@link
-   listMonitoredResourceDescriptors} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * This fetches the paged responses for {@link listMonitoredResourceDescriptors} continuously
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -772,15 +727,10 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
-   *   An object stream which emits an object representing
-   [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor}
-   on 'data' event.
+   *   An object stream which emits an object representing [MonitoredResourceDescriptor]{@link google.api.MonitoredResourceDescriptor} on 'data' event.
    *
    * @example
    *
@@ -802,7 +752,10 @@ class LoggingServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listMonitoredResourceDescriptors.createStream(
-        this._innerApiCalls.listMonitoredResourceDescriptors, request, options);
+      this._innerApiCalls.listMonitoredResourceDescriptors,
+      request,
+      options
+    );
   };
 
   /**
@@ -825,37 +778,27 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is Array of string.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListLogsResponse]{@link google.logging.v2.ListLogsResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListLogsResponse]{@link google.logging.v2.ListLogsResponse}.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of string.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
+   *   When autoPaginate: false is specified through options, the array has three elements.
    *   The first element is Array of string in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListLogsResponse]{@link
-   google.logging.v2.ListLogsResponse}.
+   *   an object representing [ListLogsResponse]{@link google.logging.v2.ListLogsResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -919,8 +862,7 @@ class LoggingServiceV2Client {
    * Equivalent to {@link listLogs}, but returns a NodeJS Stream object.
    *
    * This fetches the paged responses for {@link listLogs} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -945,11 +887,8 @@ class LoggingServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
    *   An object stream which emits a string on 'data' event.
    *
@@ -973,7 +912,10 @@ class LoggingServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listLogs.createStream(
-        this._innerApiCalls.listLogs, request, options);
+      this._innerApiCalls.listLogs,
+      request,
+      options
+    );
   };
 
   // --------------------
@@ -1014,7 +956,9 @@ class LoggingServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromLogName(logName) {
-    return this._pathTemplates.logPathTemplate.match(logName).project;
+    return this._pathTemplates.logPathTemplate
+      .match(logName)
+      .project;
   }
 
   /**
@@ -1025,7 +969,9 @@ class LoggingServiceV2Client {
    * @returns {String} - A string representing the log.
    */
   matchLogFromLogName(logName) {
-    return this._pathTemplates.logPathTemplate.match(logName).log;
+    return this._pathTemplates.logPathTemplate
+      .match(logName)
+      .log;
   }
 
   /**
@@ -1036,7 +982,9 @@ class LoggingServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromProjectName(projectName) {
-    return this._pathTemplates.projectPathTemplate.match(projectName).project;
+    return this._pathTemplates.projectPathTemplate
+      .match(projectName)
+      .project;
   }
 }
 

--- a/src/v2/metrics_service_v2_client.js
+++ b/src/v2/metrics_service_v2_client.js
@@ -48,10 +48,8 @@ class MetricsServiceV2Client {
    *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
    *     the environment variable GCLOUD_PROJECT for your project ID. If your
    *     app is running in an environment which supports
-   *     {@link
-   * https://developers.google.com/identity/protocols/application-default-credentials
-   * Application Default Credentials}, your project ID will be detected
-   * automatically.
+   *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+   *     your project ID will be detected automatically.
    * @param {function} [options.promise] - Custom promise module to use instead
    *     of native Promises.
    * @param {string} [options.servicePath] - The domain name of the
@@ -62,12 +60,13 @@ class MetricsServiceV2Client {
 
     // Ensure that options include the service address and port.
     opts = Object.assign(
-        {
-          clientConfig: {},
-          port: this.constructor.port,
-          servicePath: this.constructor.servicePath,
-        },
-        opts);
+      {
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      },
+      opts
+    );
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
@@ -90,32 +89,43 @@ class MetricsServiceV2Client {
 
     // Load the applicable protos.
     const protos = merge(
-        {},
-        gaxGrpc.loadProto(
-            path.join(__dirname, '..', '..', 'protos'),
-            'google/logging/v2/logging_metrics.proto'));
+      {},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'google/logging/v2/logging_metrics.proto'
+      )
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gax.PathTemplate('projects/{project}'),
-      metricPathTemplate:
-          new gax.PathTemplate('projects/{project}/metrics/{metric}'),
+      projectPathTemplate: new gax.PathTemplate(
+        'projects/{project}'
+      ),
+      metricPathTemplate: new gax.PathTemplate(
+        'projects/{project}/metrics/{metric}'
+      ),
     };
 
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listLogMetrics:
-          new gax.PageDescriptor('pageToken', 'nextPageToken', 'metrics'),
+      listLogMetrics: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'metrics'
+      ),
     };
 
     // Put together the default options sent with requests.
     const defaults = gaxGrpc.constructSettings(
-        'google.logging.v2.MetricsServiceV2', gapicConfig, opts.clientConfig,
-        {'x-goog-api-client': clientHeader.join(' ')});
+      'google.logging.v2.MetricsServiceV2',
+      gapicConfig,
+      opts.clientConfig,
+      {'x-goog-api-client': clientHeader.join(' ')}
+    );
 
     // Set up a dictionary of "inner API calls"; the core implementation
     // of calling the API is handled in `google-gax`, with this code
@@ -124,8 +134,10 @@ class MetricsServiceV2Client {
 
     // Put together the "service stub" for
     // google.logging.v2.MetricsServiceV2.
-    const metricsServiceV2Stub =
-        gaxGrpc.createStub(protos.google.logging.v2.MetricsServiceV2, opts);
+    const metricsServiceV2Stub = gaxGrpc.createStub(
+      protos.google.logging.v2.MetricsServiceV2,
+      opts
+    );
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -138,11 +150,16 @@ class MetricsServiceV2Client {
     ];
     for (const methodName of metricsServiceV2StubMethods) {
       this._innerApiCalls[methodName] = gax.createApiCall(
-          metricsServiceV2Stub.then(stub => function() {
-            const args = Array.prototype.slice.call(arguments, 0);
-            return stub[methodName].apply(stub, args);
-          }),
-          defaults[methodName], this._descriptors.page[methodName]);
+        metricsServiceV2Stub.then(
+          stub =>
+            function() {
+              const args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }
+        ),
+        defaults[methodName],
+        this._descriptors.page[methodName]
+      );
     }
   }
 
@@ -203,40 +220,27 @@ class MetricsServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is Array of [LogMetric]{@link
-   google.logging.v2.LogMetric}.
+   *   The second parameter to the callback is Array of [LogMetric]{@link google.logging.v2.LogMetric}.
    *
-   *   When autoPaginate: false is specified through options, it contains the
-   result
-   *   in a single response. If the response indicates the next page exists, the
-   third
-   *   parameter is set to be used for the next request object. The fourth
-   parameter keeps
-   *   the raw response object of an object representing
-   [ListLogMetricsResponse]{@link google.logging.v2.ListLogMetricsResponse}.
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListLogMetricsResponse]{@link google.logging.v2.ListLogMetricsResponse}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of [LogMetric]{@link
-   google.logging.v2.LogMetric}.
+   *   The first element of the array is Array of [LogMetric]{@link google.logging.v2.LogMetric}.
    *
-   *   When autoPaginate: false is specified through options, the array has
-   three elements.
-   *   The first element is Array of [LogMetric]{@link
-   google.logging.v2.LogMetric} in a single response.
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [LogMetric]{@link google.logging.v2.LogMetric} in a single response.
    *   The second element is the next request object if the response
    *   indicates the next page exists, or null. The third element is
-   *   an object representing [ListLogMetricsResponse]{@link
-   google.logging.v2.ListLogMetricsResponse}.
+   *   an object representing [ListLogMetricsResponse]{@link google.logging.v2.ListLogMetricsResponse}.
    *
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -300,8 +304,7 @@ class MetricsServiceV2Client {
    * Equivalent to {@link listLogMetrics}, but returns a NodeJS Stream object.
    *
    * This fetches the paged responses for {@link listLogMetrics} continuously
-   * and invokes the callback registered for 'data' event for each element in
-   the
+   * and invokes the callback registered for 'data' event for each element in the
    * responses.
    *
    * The returned object has 'end' method when no more elements are required.
@@ -323,14 +326,10 @@ class MetricsServiceV2Client {
    *   performed per-page, this determines the maximum number of
    *   resources in a page.
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @returns {Stream}
-   *   An object stream which emits an object representing [LogMetric]{@link
-   google.logging.v2.LogMetric} on 'data' event.
+   *   An object stream which emits an object representing [LogMetric]{@link google.logging.v2.LogMetric} on 'data' event.
    *
    * @example
    *
@@ -352,7 +351,10 @@ class MetricsServiceV2Client {
     options = options || {};
 
     return this._descriptors.page.listLogMetrics.createStream(
-        this._innerApiCalls.listLogMetrics, request, options);
+      this._innerApiCalls.listLogMetrics,
+      request,
+      options
+    );
   };
 
   /**
@@ -365,21 +367,15 @@ class MetricsServiceV2Client {
    *
    *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The second parameter to the callback is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -424,24 +420,17 @@ class MetricsServiceV2Client {
    *   The new logs-based metric, which must not have an identifier that
    *   already exists.
    *
-   *   This object should have the same structure as [LogMetric]{@link
-   google.logging.v2.LogMetric}
+   *   This object should have the same structure as [LogMetric]{@link google.logging.v2.LogMetric}
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The second parameter to the callback is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -492,24 +481,17 @@ class MetricsServiceV2Client {
    * @param {Object} request.metric
    *   The updated metric.
    *
-   *   This object should have the same structure as [LogMetric]{@link
-   google.logging.v2.LogMetric}
+   *   This object should have the same structure as [LogMetric]{@link google.logging.v2.LogMetric}
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
-   *   The second parameter to the callback is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The second parameter to the callback is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
    * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing
-   [LogMetric]{@link google.logging.v2.LogMetric}.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The first element of the array is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -554,16 +536,12 @@ class MetricsServiceV2Client {
    *
    *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @param {Object} [options]
-   *   Optional parameters. You can override the default settings for this call,
-   e.g, timeout,
-   *   retries, paginations, etc. See [gax.CallOptions]{@link
-   https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
-   details.
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
    * @param {function(?Error)} [callback]
    *   The function which will be called with the result of the API call.
    * @returns {Promise} - The promise which resolves when API call finishes.
-   *   The promise has a method named "cancel" which cancels the ongoing API
-   call.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
    *
    * @example
    *
@@ -626,7 +604,9 @@ class MetricsServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromProjectName(projectName) {
-    return this._pathTemplates.projectPathTemplate.match(projectName).project;
+    return this._pathTemplates.projectPathTemplate
+      .match(projectName)
+      .project;
   }
 
   /**
@@ -637,7 +617,9 @@ class MetricsServiceV2Client {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromMetricName(metricName) {
-    return this._pathTemplates.metricPathTemplate.match(metricName).project;
+    return this._pathTemplates.metricPathTemplate
+      .match(metricName)
+      .project;
   }
 
   /**
@@ -648,7 +630,9 @@ class MetricsServiceV2Client {
    * @returns {String} - A string representing the metric.
    */
   matchMetricFromMetricName(metricName) {
-    return this._pathTemplates.metricPathTemplate.match(metricName).metric;
+    return this._pathTemplates.metricPathTemplate
+      .match(metricName)
+      .metric;
   }
 }
 

--- a/synth.py
+++ b/synth.py
@@ -51,7 +51,7 @@ s.replace(
 
 # Copy in templated files
 common_templates = gcp.CommonTemplates()
-templates = common_templates.node_library()
+templates = common_templates.node_library(source_location='build/src')
 s.copy(templates)
 
 # Node.js specific cleanup

--- a/test/gapic-v2.js
+++ b/test/gapic-v2.js
@@ -14,14 +14,13 @@
 
 'use strict';
 
-import * as assert from 'assert';
-import {ApiError} from '@google-cloud/common';
+const assert = require('assert');
 
 const loggingModule = require('../src');
 
 const FAKE_STATUS_CODE = 1;
 const error = new Error();
-(error as ApiError).code = FAKE_STATUS_CODE;
+error.code = FAKE_STATUS_CODE;
 
 describe('LoggingServiceV2Client', () => {
   describe('deleteLog', () => {
@@ -59,8 +58,11 @@ describe('LoggingServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.deleteLog =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteLog = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.deleteLog(request, err => {
         assert(err instanceof Error);
@@ -80,15 +82,17 @@ describe('LoggingServiceV2Client', () => {
       // Mock request
       const entries = [];
       const request = {
-        entries,
+        entries: entries,
       };
 
       // Mock response
       const expectedResponse = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.writeLogEntries =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.writeLogEntries = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.writeLogEntries(request, (err, response) => {
         assert.ifError(err);
@@ -106,12 +110,15 @@ describe('LoggingServiceV2Client', () => {
       // Mock request
       const entries = [];
       const request = {
-        entries,
+        entries: entries,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.writeLogEntries =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.writeLogEntries = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.writeLogEntries(request, (err, response) => {
         assert(err instanceof Error);
@@ -140,16 +147,15 @@ describe('LoggingServiceV2Client', () => {
       const entriesElement = {};
       const entries = [entriesElement];
       const expectedResponse = {
-        nextPageToken,
-        entries,
+        nextPageToken: nextPageToken,
+        entries: entries,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listLogEntries =
-          (actualRequest, options, callback) => {
-            assert.deepStrictEqual(actualRequest, request);
-            callback(null, expectedResponse.entries);
-          };
+      client._innerApiCalls.listLogEntries = (actualRequest, options, callback) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.entries);
+      };
 
       client.listLogEntries(request, (err, response) => {
         assert.ifError(err);
@@ -171,8 +177,11 @@ describe('LoggingServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listLogEntries =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listLogEntries = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listLogEntries(request, (err, response) => {
         assert(err instanceof Error);
@@ -198,16 +207,15 @@ describe('LoggingServiceV2Client', () => {
       const resourceDescriptorsElement = {};
       const resourceDescriptors = [resourceDescriptorsElement];
       const expectedResponse = {
-        nextPageToken,
-        resourceDescriptors,
+        nextPageToken: nextPageToken,
+        resourceDescriptors: resourceDescriptors,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listMonitoredResourceDescriptors =
-          (actualRequest, options, callback) => {
-            assert.deepStrictEqual(actualRequest, request);
-            callback(null, expectedResponse.resourceDescriptors);
-          };
+      client._innerApiCalls.listMonitoredResourceDescriptors = (actualRequest, options, callback) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.resourceDescriptors);
+      };
 
       client.listMonitoredResourceDescriptors(request, (err, response) => {
         assert.ifError(err);
@@ -226,8 +234,11 @@ describe('LoggingServiceV2Client', () => {
       const request = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.listMonitoredResourceDescriptors =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listMonitoredResourceDescriptors = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listMonitoredResourceDescriptors(request, (err, response) => {
         assert(err instanceof Error);
@@ -256,8 +267,8 @@ describe('LoggingServiceV2Client', () => {
       const logNamesElement = 'logNamesElement-1079688374';
       const logNames = [logNamesElement];
       const expectedResponse = {
-        nextPageToken,
-        logNames,
+        nextPageToken: nextPageToken,
+        logNames: logNames,
       };
 
       // Mock Grpc layer
@@ -286,8 +297,11 @@ describe('LoggingServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listLogs =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listLogs = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listLogs(request, (err, response) => {
         assert(err instanceof Error);
@@ -297,6 +311,7 @@ describe('LoggingServiceV2Client', () => {
       });
     });
   });
+
 });
 describe('ConfigServiceV2Client', () => {
   describe('listSinks', () => {
@@ -317,8 +332,8 @@ describe('ConfigServiceV2Client', () => {
       const sinksElement = {};
       const sinks = [sinksElement];
       const expectedResponse = {
-        nextPageToken,
-        sinks,
+        nextPageToken: nextPageToken,
+        sinks: sinks,
       };
 
       // Mock Grpc layer
@@ -347,8 +362,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listSinks =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listSinks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listSinks(request, (err, response) => {
         assert(err instanceof Error);
@@ -379,16 +397,18 @@ describe('ConfigServiceV2Client', () => {
       const writerIdentity = 'writerIdentity775638794';
       const includeChildren = true;
       const expectedResponse = {
-        name,
-        destination,
-        filter,
-        writerIdentity,
-        includeChildren,
+        name: name,
+        destination: destination,
+        filter: filter,
+        writerIdentity: writerIdentity,
+        includeChildren: includeChildren,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getSink =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getSink = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.getSink(request, (err, response) => {
         assert.ifError(err);
@@ -410,8 +430,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getSink =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getSink = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.getSink(request, (err, response) => {
         assert(err instanceof Error);
@@ -434,7 +457,7 @@ describe('ConfigServiceV2Client', () => {
       const sink = {};
       const request = {
         parent: formattedParent,
-        sink,
+        sink: sink,
       };
 
       // Mock response
@@ -444,16 +467,18 @@ describe('ConfigServiceV2Client', () => {
       const writerIdentity = 'writerIdentity775638794';
       const includeChildren = true;
       const expectedResponse = {
-        name,
-        destination,
-        filter,
-        writerIdentity,
-        includeChildren,
+        name: name,
+        destination: destination,
+        filter: filter,
+        writerIdentity: writerIdentity,
+        includeChildren: includeChildren,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createSink =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createSink = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.createSink(request, (err, response) => {
         assert.ifError(err);
@@ -473,12 +498,15 @@ describe('ConfigServiceV2Client', () => {
       const sink = {};
       const request = {
         parent: formattedParent,
-        sink,
+        sink: sink,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createSink =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createSink = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.createSink(request, (err, response) => {
         assert(err instanceof Error);
@@ -501,7 +529,7 @@ describe('ConfigServiceV2Client', () => {
       const sink = {};
       const request = {
         sinkName: formattedSinkName,
-        sink,
+        sink: sink,
       };
 
       // Mock response
@@ -511,16 +539,18 @@ describe('ConfigServiceV2Client', () => {
       const writerIdentity = 'writerIdentity775638794';
       const includeChildren = true;
       const expectedResponse = {
-        name,
-        destination,
-        filter,
-        writerIdentity,
-        includeChildren,
+        name: name,
+        destination: destination,
+        filter: filter,
+        writerIdentity: writerIdentity,
+        includeChildren: includeChildren,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateSink =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.updateSink = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.updateSink(request, (err, response) => {
         assert.ifError(err);
@@ -540,12 +570,15 @@ describe('ConfigServiceV2Client', () => {
       const sink = {};
       const request = {
         sinkName: formattedSinkName,
-        sink,
+        sink: sink,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateSink =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateSink = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.updateSink(request, (err, response) => {
         assert(err instanceof Error);
@@ -591,8 +624,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.deleteSink =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteSink = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.deleteSink(request, err => {
         assert(err instanceof Error);
@@ -620,16 +656,15 @@ describe('ConfigServiceV2Client', () => {
       const exclusionsElement = {};
       const exclusions = [exclusionsElement];
       const expectedResponse = {
-        nextPageToken,
-        exclusions,
+        nextPageToken: nextPageToken,
+        exclusions: exclusions,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listExclusions =
-          (actualRequest, options, callback) => {
-            assert.deepStrictEqual(actualRequest, request);
-            callback(null, expectedResponse.exclusions);
-          };
+      client._innerApiCalls.listExclusions = (actualRequest, options, callback) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.exclusions);
+      };
 
       client.listExclusions(request, (err, response) => {
         assert.ifError(err);
@@ -651,8 +686,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listExclusions =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listExclusions = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listExclusions(request, (err, response) => {
         assert(err instanceof Error);
@@ -683,14 +721,16 @@ describe('ConfigServiceV2Client', () => {
       const disabled = true;
       const expectedResponse = {
         name: name2,
-        description,
-        filter,
-        disabled,
+        description: description,
+        filter: filter,
+        disabled: disabled,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getExclusion =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getExclusion = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.getExclusion(request, (err, response) => {
         assert.ifError(err);
@@ -712,8 +752,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getExclusion =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getExclusion = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.getExclusion(request, (err, response) => {
         assert(err instanceof Error);
@@ -736,7 +779,7 @@ describe('ConfigServiceV2Client', () => {
       const exclusion = {};
       const request = {
         parent: formattedParent,
-        exclusion,
+        exclusion: exclusion,
       };
 
       // Mock response
@@ -745,15 +788,17 @@ describe('ConfigServiceV2Client', () => {
       const filter = 'filter-1274492040';
       const disabled = true;
       const expectedResponse = {
-        name,
-        description,
-        filter,
-        disabled,
+        name: name,
+        description: description,
+        filter: filter,
+        disabled: disabled,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createExclusion =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createExclusion = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.createExclusion(request, (err, response) => {
         assert.ifError(err);
@@ -773,12 +818,15 @@ describe('ConfigServiceV2Client', () => {
       const exclusion = {};
       const request = {
         parent: formattedParent,
-        exclusion,
+        exclusion: exclusion,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createExclusion =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createExclusion = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.createExclusion(request, (err, response) => {
         assert(err instanceof Error);
@@ -802,8 +850,8 @@ describe('ConfigServiceV2Client', () => {
       const updateMask = {};
       const request = {
         name: formattedName,
-        exclusion,
-        updateMask,
+        exclusion: exclusion,
+        updateMask: updateMask,
       };
 
       // Mock response
@@ -813,14 +861,16 @@ describe('ConfigServiceV2Client', () => {
       const disabled = true;
       const expectedResponse = {
         name: name2,
-        description,
-        filter,
-        disabled,
+        description: description,
+        filter: filter,
+        disabled: disabled,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateExclusion =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.updateExclusion = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.updateExclusion(request, (err, response) => {
         assert.ifError(err);
@@ -841,13 +891,16 @@ describe('ConfigServiceV2Client', () => {
       const updateMask = {};
       const request = {
         name: formattedName,
-        exclusion,
-        updateMask,
+        exclusion: exclusion,
+        updateMask: updateMask,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateExclusion =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateExclusion = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.updateExclusion(request, (err, response) => {
         assert(err instanceof Error);
@@ -893,8 +946,11 @@ describe('ConfigServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.deleteExclusion =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteExclusion = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.deleteExclusion(request, err => {
         assert(err instanceof Error);
@@ -903,6 +959,7 @@ describe('ConfigServiceV2Client', () => {
       });
     });
   });
+
 });
 describe('MetricsServiceV2Client', () => {
   describe('listLogMetrics', () => {
@@ -923,16 +980,15 @@ describe('MetricsServiceV2Client', () => {
       const metricsElement = {};
       const metrics = [metricsElement];
       const expectedResponse = {
-        nextPageToken,
-        metrics,
+        nextPageToken: nextPageToken,
+        metrics: metrics,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listLogMetrics =
-          (actualRequest, options, callback) => {
-            assert.deepStrictEqual(actualRequest, request);
-            callback(null, expectedResponse.metrics);
-          };
+      client._innerApiCalls.listLogMetrics = (actualRequest, options, callback) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.metrics);
+      };
 
       client.listLogMetrics(request, (err, response) => {
         assert.ifError(err);
@@ -954,8 +1010,11 @@ describe('MetricsServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.listLogMetrics =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listLogMetrics = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.listLogMetrics(request, (err, response) => {
         assert(err instanceof Error);
@@ -985,15 +1044,17 @@ describe('MetricsServiceV2Client', () => {
       const filter = 'filter-1274492040';
       const valueExtractor = 'valueExtractor2047672534';
       const expectedResponse = {
-        name,
-        description,
-        filter,
-        valueExtractor,
+        name: name,
+        description: description,
+        filter: filter,
+        valueExtractor: valueExtractor,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getLogMetric =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getLogMetric = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.getLogMetric(request, (err, response) => {
         assert.ifError(err);
@@ -1015,8 +1076,11 @@ describe('MetricsServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.getLogMetric =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getLogMetric = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.getLogMetric(request, (err, response) => {
         assert(err instanceof Error);
@@ -1039,7 +1103,7 @@ describe('MetricsServiceV2Client', () => {
       const metric = {};
       const request = {
         parent: formattedParent,
-        metric,
+        metric: metric,
       };
 
       // Mock response
@@ -1048,15 +1112,17 @@ describe('MetricsServiceV2Client', () => {
       const filter = 'filter-1274492040';
       const valueExtractor = 'valueExtractor2047672534';
       const expectedResponse = {
-        name,
-        description,
-        filter,
-        valueExtractor,
+        name: name,
+        description: description,
+        filter: filter,
+        valueExtractor: valueExtractor,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createLogMetric =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createLogMetric = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.createLogMetric(request, (err, response) => {
         assert.ifError(err);
@@ -1076,12 +1142,15 @@ describe('MetricsServiceV2Client', () => {
       const metric = {};
       const request = {
         parent: formattedParent,
-        metric,
+        metric: metric,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.createLogMetric =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createLogMetric = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.createLogMetric(request, (err, response) => {
         assert(err instanceof Error);
@@ -1104,7 +1173,7 @@ describe('MetricsServiceV2Client', () => {
       const metric = {};
       const request = {
         metricName: formattedMetricName,
-        metric,
+        metric: metric,
       };
 
       // Mock response
@@ -1113,15 +1182,17 @@ describe('MetricsServiceV2Client', () => {
       const filter = 'filter-1274492040';
       const valueExtractor = 'valueExtractor2047672534';
       const expectedResponse = {
-        name,
-        description,
-        filter,
-        valueExtractor,
+        name: name,
+        description: description,
+        filter: filter,
+        valueExtractor: valueExtractor,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateLogMetric =
-          mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.updateLogMetric = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       client.updateLogMetric(request, (err, response) => {
         assert.ifError(err);
@@ -1141,12 +1212,15 @@ describe('MetricsServiceV2Client', () => {
       const metric = {};
       const request = {
         metricName: formattedMetricName,
-        metric,
+        metric: metric,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.updateLogMetric =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateLogMetric = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.updateLogMetric(request, (err, response) => {
         assert(err instanceof Error);
@@ -1192,8 +1266,11 @@ describe('MetricsServiceV2Client', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.deleteLogMetric =
-          mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteLogMetric = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       client.deleteLogMetric(request, err => {
         assert(err instanceof Error);
@@ -1202,10 +1279,11 @@ describe('MetricsServiceV2Client', () => {
       });
     });
   });
+
 });
 
-function mockSimpleGrpcMethod(expectedRequest, response?, error?) {
-  return (actualRequest, options, callback) => {
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {
       callback(error);


### PR DESCRIPTION
So this commit solves a few problems, mostly around the generation process.
1. Currently we're pretty standardized on prettier+eslint for formatting of samples.  We have templates that are copied over during the generation process that assume prettier will be there.  For the sake of consistency, I've gone ahead and added that back.
2. During the TypeScript converstion, we moved `test/gapic-v2.js` over to TypeScript.  However... this is a generated file.  I instead changed the build to just copy this file as-is over to build/test.