### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "prettier": "^1.15.1",
     "proxyquire": "^2.1.0",
     "typescript": "~3.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "@types/sinon": "5.0.5"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.