### PR TITLE
feat: cache detected environment's default resource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ class Logging {
   auth: GoogleAuth;
   options: LoggingOptions;
   projectId: string;
+  detectedResource?: object;
 
   constructor(options?: LoggingOptions) {
     // Determine what scopes are needed.

--- a/src/log.ts
+++ b/src/log.ts
@@ -80,7 +80,6 @@ export interface WriteOptions {
  * const log = logging.log('syslog');
  */
 class Log {
-  detectedResource_?: object;
   formattedName_: string;
   removeCircular_: boolean;
   logging: Logging;
@@ -767,13 +766,13 @@ class Log {
           options.resource.labels = snakeCaseKeys(options.resource.labels);
         }
         writeWithResource(options.resource);
-      } else if (this.detectedResource_) {
-        writeWithResource(this.detectedResource_);
+      } else if (this.logging.detectedResource) {
+        writeWithResource(this.logging.detectedResource);
       } else {
         getDefaultResource(this.logging.auth)
             .then(
                 (resource) => {
-                  this.detectedResource_ = resource;
+                  this.logging.detectedResource = resource;
                   writeWithResource(resource);
                 },
                 () => {

--- a/test/log.ts
+++ b/test/log.ts
@@ -351,7 +351,7 @@ describe('Log', () => {
       };
 
       log.logging.request = () => {
-        assert.strictEqual(log.detectedResource_, fakeResource);
+        assert.strictEqual(log.logging.detectedResource, fakeResource);
         done();
       };
 
@@ -359,22 +359,15 @@ describe('Log', () => {
     });
 
     it('should re-use detected resource', done => {
-      const fakeResource = 'test-level-fake-resource';
+      log.logging.detectedResource = 'environment-default-resource';
 
-      let numTimesDefaultResourceFetched = 0;
-
-      fakeMetadata.getDefaultResource = async () => {
-        numTimesDefaultResourceFetched++;
-
-        if (numTimesDefaultResourceFetched > 1) {
-          throw new Error('Cached resource was not used.');
-        }
-
-        return fakeResource;
+      fakeMetadata.getDefaultResource = () => {
+        throw new Error('Cached resource was not used.');
       };
 
       log.logging.request = config => {
-        assert.deepStrictEqual(config.reqOpts.resource, fakeResource);
+        assert.strictEqual(
+            config.reqOpts.resource, log.logging.detectedResource);
         done();
       };
 


### PR DESCRIPTION
Fixes #353

This will cache the environment's default resource, instead of pinging for it on every `log.write()` request.