### PR TITLE
fix: stop exporting express types publicly

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@google-cloud/pubsub": "^0.23.0",
     "@google-cloud/storage": "^2.2.0",
     "@types/arrify": "^1.0.4",
-    "@types/express": "^4.16.0",
     "@types/extend": "^3.0.0",
     "@types/is": "0.0.21",
     "@types/mocha": "^5.2.5",

--- a/src/middleware/express/make-http-request.ts
+++ b/src/middleware/express/make-http-request.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-// Types-only import.
-import {Request, Response} from 'express';
+import * as http from 'http';
 
 import {StackdriverHttpRequest} from '../../http-request';
 
 export function makeHttpRequestData(
-    req: Request, res: Response,
+    req: http.IncomingMessage, res: http.ServerResponse,
     latencyMilliseconds: number): StackdriverHttpRequest {
   return {
     status: res.statusCode,

--- a/src/middleware/express/make-middleware.ts
+++ b/src/middleware/express/make-middleware.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+import * as http from 'http';
 import onFinished = require('on-finished');
 import {getOrInjectContext, makeHeaderWrapper} from '../context';
-// Types-only import.
-import {Request, Response, NextFunction} from 'express';
+
 import {makeHttpRequestData} from './make-http-request';
 import {StackdriverHttpRequest} from '../../http-request';
 
-export interface AnnotatedRequestType<LoggerType> extends Request {
+interface AnnotatedRequestType<LoggerType> extends http.IncomingMessage {
   log: LoggerType;
 }
 
@@ -45,7 +45,8 @@ export function makeMiddleware<LoggerType>(
     projectId: string, makeChildLogger: (trace: string) => LoggerType,
     emitRequestLog?: (httpRequest: StackdriverHttpRequest, trace: string) =>
         void) {
-  return (req: Request, res: Response, next: NextFunction) => {
+  return (req: http.IncomingMessage, res: http.ServerResponse,
+          next: Function) => {
     // TODO(ofrobots): use high-resolution timer.
     const requestStartMs = Date.now();
 

--- a/test/middleware/express/test-make-http-request.ts
+++ b/test/middleware/express/test-make-http-request.ts
@@ -15,8 +15,7 @@
  */
 
 import * as assert from 'assert';
-// Types-only import.
-import {Request, Response} from 'express';
+import {IncomingMessage, ServerResponse} from 'http';
 import {makeHttpRequestData} from '../../../src/middleware/express/make-http-request';
 
 describe('middleware/express/make-http-request', () => {
@@ -25,16 +24,17 @@ describe('middleware/express/make-http-request', () => {
     const fakeResponse = {};
 
     const h1 = makeHttpRequestData(
-        fakeRequest as Request, fakeResponse as Response, 1003);
+        fakeRequest as IncomingMessage, fakeResponse as ServerResponse, 1003);
     assert.deepStrictEqual(h1.latency, {seconds: 1, nanos: 3e6});
 
     const h2 = makeHttpRequestData(
-        fakeRequest as Request, fakeResponse as Response, 9003.1);
+        fakeRequest as IncomingMessage, fakeResponse as ServerResponse, 9003.1);
     assert.deepStrictEqual(h2.latency, {seconds: 9, nanos: 3.1e6});
 
     // Make sure we nanos is uint32.
     const h3 = makeHttpRequestData(
-        fakeRequest as Request, fakeResponse as Response, 1.0000000001);
+        fakeRequest as IncomingMessage, fakeResponse as ServerResponse,
+        1.0000000001);
     assert.deepStrictEqual(h3.latency, {seconds: 0, nanos: 1e6});
   });
 });


### PR DESCRIPTION
We don't have a dependency on express. If we expose express types
as part of our public, our dependent modules will need to have a dev
dependency on @types/express. Otherwise they see their builds failing.
Currently there is no way to express this dependency relationship to
npm.

Instead, let's not use express types.

Ref: https://github.com/googleapis/nodejs-logging-bunyan/issues/243
