### PR TITLE
chore: use proper enum for GCPEnv

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -16,7 +16,7 @@
 
 import * as fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';
-import {GoogleAuth} from 'google-auth-library';
+import {GCPEnv, GoogleAuth} from 'google-auth-library';
 import * as pify from 'pify';
 
 const readFile = pify(fs.readFile);
@@ -139,13 +139,13 @@ export function getGlobalDescriptor() {
 export async function getDefaultResource(auth: GoogleAuth) {
   const env = await auth.getEnv();
   switch (env) {
-    case 'KUBERNETES_ENGINE':
+    case GCPEnv.KUBERNETES_ENGINE:
       return getGKEDescriptor();
-    case 'APP_ENGINE':
+    case GCPEnv.APP_ENGINE:
       return getGAEDescriptor();
-    case 'CLOUD_FUNCTIONS':
+    case GCPEnv.CLOUD_FUNCTIONS:
       return getCloudFunctionDescriptor();
-    case 'COMPUTE_ENGINE':
+    case GCPEnv.COMPUTE_ENGINE:
       // Test for compute engine should be done after all the rest -
       // everything runs on top of compute engine.
       return getGCEDescriptor();

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -17,7 +17,9 @@
 import * as assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as extend from 'extend';
+import {GCPEnv} from 'google-auth-library';
 import * as proxyquire from 'proxyquire';
+
 import assertRejects = require('assert-rejects');
 
 let instanceOverride;
@@ -213,7 +215,7 @@ describe('metadata', () => {
 
           const fakeAuth = {
             async getEnv() {
-              return 'APP_ENGINE';
+              return GCPEnv.APP_ENGINE;
             }
           };
 
@@ -238,7 +240,7 @@ describe('metadata', () => {
 
           const fakeAuth = {
             async getEnv() {
-              return 'CLOUD_FUNCTIONS';
+              return GCPEnv.CLOUD_FUNCTIONS;
             }
           };
 
@@ -271,7 +273,7 @@ describe('metadata', () => {
 
           const fakeAuth = {
             async getEnv() {
-              return 'COMPUTE_ENGINE';
+              return GCPEnv.COMPUTE_ENGINE;
             }
           };
           const defaultResource = await metadata.getDefaultResource(fakeAuth);
@@ -302,7 +304,7 @@ describe('metadata', () => {
 
           const fakeAuth = {
             async getEnv() {
-              return 'COMPUTE_ENGINE';
+              return GCPEnv.COMPUTE_ENGINE;
             }
           };
 
@@ -327,7 +329,7 @@ describe('metadata', () => {
 
           const fakeAuth = {
             async getEnv() {
-              return 'KUBERNETES_ENGINE';
+              return GCPEnv.KUBERNETES_ENGINE;
             }
           };
 
@@ -346,7 +348,7 @@ describe('metadata', () => {
         it('should return correct descriptor', async () => {
           const fakeAuth = {
             async getEnv() {
-              return 'NONE';
+              return GCPEnv.NONE;
             }
           };
 


### PR DESCRIPTION
Strings can have typos. Use enum now that it is exported from
google-auth-library.

