### PR TITLE
test: reap deleted resources to avoid collisions

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -828,7 +828,8 @@ class Log implements LogSeverityFunctions {
                   this.logging.detectedResource = resource;
                   writeWithResource(resource);
                 },
-                () => {
+                (err) => {
+                  console.log(err)
                   // Ignore errors (the API will speak up if it has an issue).
                   writeWithResource(null);
                 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -829,7 +829,7 @@ class Log implements LogSeverityFunctions {
                   writeWithResource(resource);
                 },
                 (err) => {
-                  console.log(err)
+                  console.log(err);
                   // Ignore errors (the API will speak up if it has an issue).
                   writeWithResource(null);
                 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -822,17 +822,10 @@ class Log implements LogSeverityFunctions {
       } else if (this.logging.detectedResource) {
         writeWithResource(this.logging.detectedResource);
       } else {
-        getDefaultResource(this.logging.auth)
-            .then(
-                (resource) => {
-                  this.logging.detectedResource = resource;
-                  writeWithResource(resource);
-                },
-                (err) => {
-                  console.log(err);
-                  // Ignore errors (the API will speak up if it has an issue).
-                  writeWithResource(null);
-                });
+        getDefaultResource(this.logging.auth).then((resource) => {
+          this.logging.detectedResource = resource;
+          writeWithResource(resource);
+        });
       }
       function writeWithResource(resource: {}|null) {
         let decoratedEntries;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -140,19 +140,23 @@ export function getGlobalDescriptor() {
  */
 export async function getDefaultResource(auth: GoogleAuth) {
   const env = await auth.getEnv();
-  switch (env) {
-    case GCPEnv.KUBERNETES_ENGINE:
-      return getGKEDescriptor();
-    case GCPEnv.APP_ENGINE:
-      return getGAEDescriptor();
-    case GCPEnv.CLOUD_FUNCTIONS:
-      return getCloudFunctionDescriptor();
-    case GCPEnv.COMPUTE_ENGINE:
-      // Test for compute engine should be done after all the rest -
-      // everything runs on top of compute engine.
-      return getGCEDescriptor();
-    default:
-      return getGlobalDescriptor();
+  try {
+    switch (env) {
+      case GCPEnv.KUBERNETES_ENGINE:
+        return getGKEDescriptor();
+      case GCPEnv.APP_ENGINE:
+        return getGAEDescriptor();
+      case GCPEnv.CLOUD_FUNCTIONS:
+        return getCloudFunctionDescriptor();
+      case GCPEnv.COMPUTE_ENGINE:
+        // Test for compute engine should be done after all the rest -
+        // everything runs on top of compute engine.
+        return getGCEDescriptor();
+      default:
+        return getGlobalDescriptor();
+    }
+  } catch (e) {
+    return getGlobalDescriptor();
   }
 }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -140,23 +140,20 @@ export function getGlobalDescriptor() {
  */
 export async function getDefaultResource(auth: GoogleAuth) {
   const env = await auth.getEnv();
-  try {
-    switch (env) {
-      case GCPEnv.KUBERNETES_ENGINE:
-        return getGKEDescriptor();
-      case GCPEnv.APP_ENGINE:
-        return getGAEDescriptor();
-      case GCPEnv.CLOUD_FUNCTIONS:
-        return getCloudFunctionDescriptor();
-      case GCPEnv.COMPUTE_ENGINE:
-        // Test for compute engine should be done after all the rest -
-        // everything runs on top of compute engine.
-        return getGCEDescriptor();
-      default:
-        return getGlobalDescriptor();
-    }
-  } catch (e) {
-    return getGlobalDescriptor();
+
+  switch (env) {
+    case GCPEnv.KUBERNETES_ENGINE:
+      return getGKEDescriptor().catch(() => getGlobalDescriptor());
+    case GCPEnv.APP_ENGINE:
+      return getGAEDescriptor().catch(() => getGlobalDescriptor());
+    case GCPEnv.CLOUD_FUNCTIONS:
+      return getCloudFunctionDescriptor().catch(() => getGlobalDescriptor());
+    case GCPEnv.COMPUTE_ENGINE:
+      // Test for compute engine should be done after all the rest -
+      // everything runs on top of compute engine.
+      return getGCEDescriptor().catch(() => getGlobalDescriptor());
+    default:
+      return getGlobalDescriptor();
   }
 }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -141,6 +141,8 @@ export function getGlobalDescriptor() {
 export async function getDefaultResource(auth: GoogleAuth) {
   const env = await auth.getEnv();
 
+  console.log({env});
+
   switch (env) {
     case GCPEnv.KUBERNETES_ENGINE:
       return getGKEDescriptor().catch(() => getGlobalDescriptor());

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -141,8 +141,6 @@ export function getGlobalDescriptor() {
 export async function getDefaultResource(auth: GoogleAuth) {
   const env = await auth.getEnv();
 
-  console.log({env});
-
   switch (env) {
     case GCPEnv.KUBERNETES_ENGINE:
       return getGKEDescriptor().catch(() => getGlobalDescriptor());

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -147,7 +147,7 @@ export async function getDefaultResource(auth: GoogleAuth) {
     case GCPEnv.APP_ENGINE:
       return getGAEDescriptor().catch(() => getGlobalDescriptor());
     case GCPEnv.CLOUD_FUNCTIONS:
-      return getCloudFunctionDescriptor().catch(() => getGlobalDescriptor());
+      return getCloudFunctionDescriptor();
     case GCPEnv.COMPUTE_ENGINE:
       // Test for compute engine should be done after all the rest -
       // everything runs on top of compute engine.

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -31,7 +31,10 @@ import * as uuid from 'uuid';
 import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
-nock(HOST_ADDRESS).get(() => true).replyWithError({code: 'ENOTFOUND'}).persist();
+nock(HOST_ADDRESS)
+    .get(() => true)
+    .replyWithError({code: 'ENOTFOUND'})
+    .persist();
 
 describe('Logging', () => {
   let PROJECT_ID: string;

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -273,7 +273,13 @@ describe('Logging', () => {
       },
     };
 
-    after(() => Promise.all(logs.map(log => log.delete())));
+    after(async () => {
+      await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS));
+
+      for (const log of logs) {
+        await log.delete();
+      }
+    });
 
     it('should list log entries', (done) => {
       const {log, logEntries} = getTestLog();
@@ -399,7 +405,7 @@ describe('Logging', () => {
       const messages = ['1', '2', '3', '4', '5'];
 
       messages.forEach(message => {
-        log.write(log.entry(message));
+        log.write(log.entry(message), options);
       });
 
       getEntriesFromLog(log, (err, entries) => {

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -95,24 +95,19 @@ describe('Logging', () => {
 
     async function getAndDelete(method: Function) {
       const [objects] = await method();
-      return Promise.all(
-          objects
-              .filter((o: ServiceObject) => {
-                // tslint:disable-next-line no-any
-                const id = (o as any).name || o.id;
+      return Promise.all(objects
+                             .filter((o: ServiceObject) => {
+                               // tslint:disable-next-line no-any
+                               const name = (o as any).name || o.id;
 
-                if (!id.startsWith(TESTS_PREFIX)) {
-                  return false;
-                }
+                               if (!name.startsWith(TESTS_PREFIX)) {
+                                 return false;
+                               }
 
-                // Parse the time the resource was created using the resource id
-                const timeResourceCreated =
-                    Number(id.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0]);
-                const dateResourceCreated = new Date(timeResourceCreated);
-
-                return dateResourceCreated < oneHourAgo;
-              })
-              .map((o: ServiceObject) => o.delete()));
+                               return getDateFromGeneratedName(name) <
+                                   oneHourAgo;
+                             })
+                             .map((o: ServiceObject) => o.delete()));
     }
   });
 
@@ -556,5 +551,13 @@ describe('Logging', () => {
 
   function generateName() {
     return `${TESTS_PREFIX}-${Date.now()}-${uuid().split('-').pop()}`;
+  }
+
+  // Parse the time the resource was created using the resource id
+  // Format 1: ${TESTS_PREFIX}-${date}-${uuid}
+  // Format 2: ${TESTS_PREFIX}_${date}_${uuid}
+  function getDateFromGeneratedName(name) {
+    const timeCreated = name.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0];
+    return new Date(Number(timeResourceCreated));
   }
 });

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -23,6 +23,7 @@ import {ServiceObject} from '@google-cloud/common';
 import {PubSub} from '@google-cloud/pubsub';
 import {Storage} from '@google-cloud/storage';
 import * as assert from 'assert';
+import {HOST_ADDRESS} from 'gcp-metadata';
 import * as nock from 'nock';
 import {Duplex} from 'stream';
 import * as uuid from 'uuid';
@@ -30,10 +31,7 @@ import * as uuid from 'uuid';
 import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
-nock('http://metadata.google.internal')
-    .get(() => true)
-    .replyWithError({code: 'ENOTFOUND'})
-    .persist();
+nock(HOST_ADDRESS).get(() => true).replyWithError({code: 'ENOTFOUND'}).persist();
 
 describe('Logging', () => {
   let PROJECT_ID: string;

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -471,7 +471,7 @@ describe('Logging', () => {
       });
     });
 
-    it.only('should set the default resource', done => {
+    it('should set the default resource', done => {
       const {log} = getTestLog();
 
       const text = 'entry-text';

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -31,10 +31,7 @@ import * as uuid from 'uuid';
 import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
-nock(BASE_URL)
-    .get(() => true)
-    .replyWithError({code: 'ENOTFOUND'})
-    .persist();
+nock(BASE_URL).get(() => true).replyWithError({code: 'ENOTFOUND'}).persist();
 
 describe('Logging', () => {
   let PROJECT_ID: string;

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -23,7 +23,6 @@ import {ServiceObject} from '@google-cloud/common';
 import {PubSub} from '@google-cloud/pubsub';
 import {Storage} from '@google-cloud/storage';
 import * as assert from 'assert';
-import {BASE_URL} from 'gcp-metadata';
 import * as nock from 'nock';
 import {Duplex} from 'stream';
 import * as uuid from 'uuid';
@@ -31,7 +30,10 @@ import * as uuid from 'uuid';
 import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
-nock(BASE_URL).get(() => true).replyWithError({code: 'ENOTFOUND'}).persist();
+nock('http://metadata.google.internal')
+    .get(() => true)
+    .replyWithError({code: 'ENOTFOUND'})
+    .persist();
 
 describe('Logging', () => {
   let PROJECT_ID: string;
@@ -464,7 +466,7 @@ describe('Logging', () => {
       });
     });
 
-    it.only('should set the default resource', done => {
+    it('should set the default resource', done => {
       const {log} = getTestLog();
 
       const text = 'entry-text';

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -234,7 +234,7 @@ describe('Logging', () => {
 
     it('should write multiple entries to a log', async () => {
       await log.write(logEntries, options);
-      await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS*2));
+      await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS * 2));
       const [entries] = await log.getEntries({
         autoPaginate: false,
         pageSize: logEntries.length,
@@ -292,7 +292,7 @@ describe('Logging', () => {
         log.write(log.entry(message));
       });
 
-      for (let i=0; i<8; i++) {
+      for (let i = 0; i < 8; i++) {
         await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS));
         const [entries] = await log.getEntries({
           autoPaginate: false,

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -70,15 +70,15 @@ describe('Logging', () => {
       const [buckets] = await storage.getBuckets({
         prefix: TESTS_PREFIX,
       });
-      return Promise.all(
-          buckets
-              .filter(bucket => {
-                return new Date(bucket.metadata.timeCreated) < oneHourAgo;
-              })
-              .map(async bucket => {
-                await bucket.deleteFiles();
-                await bucket.delete();
-              }));
+      return Promise.all(buckets
+                             .filter(bucket => {
+                               return new Date(bucket.metadata.timeCreated) <
+                                   oneHourAgo;
+                             })
+                             .map(async bucket => {
+                               await bucket.deleteFiles();
+                               await bucket.delete();
+                             }));
     }
 
     async function deleteDatasets() {
@@ -106,7 +106,8 @@ describe('Logging', () => {
                 }
 
                 // Parse the time the resource was created using the resource id
-                const timeResourceCreated = parseInt(id.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0]);
+                const timeResourceCreated =
+                    Number(id.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0]);
                 const dateResourceCreated = new Date(timeResourceCreated);
 
                 return dateResourceCreated < oneHourAgo;

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -23,6 +23,7 @@ import {ServiceObject} from '@google-cloud/common';
 import {PubSub} from '@google-cloud/pubsub';
 import {Storage} from '@google-cloud/storage';
 import * as assert from 'assert';
+import {BASE_URL} from 'gcp-metadata';
 import * as nock from 'nock';
 import {Duplex} from 'stream';
 import * as uuid from 'uuid';
@@ -30,7 +31,7 @@ import * as uuid from 'uuid';
 import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
-nock('http://metadata.google.internal.')
+nock(BASE_URL)
     .get(() => true)
     .replyWithError({code: 'ENOTFOUND'})
     .persist();
@@ -466,7 +467,7 @@ describe('Logging', () => {
       });
     });
 
-    it('should set the default resource', done => {
+    it.only('should set the default resource', done => {
       const {log} = getTestLog();
 
       const text = 'entry-text';

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -471,7 +471,7 @@ describe('Logging', () => {
       });
     });
 
-    it('should set the default resource', done => {
+    it.only('should set the default resource', done => {
       const {log} = getTestLog();
 
       const text = 'entry-text';

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -558,6 +558,6 @@ describe('Logging', () => {
   // Format 2: ${TESTS_PREFIX}_${date}_${uuid}
   function getDateFromGeneratedName(name) {
     const timeCreated = name.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0];
-    return new Date(Number(timeResourceCreated));
+    return new Date(Number(timeCreated));
   }
 });

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-if (process.env.GOOGLE_CLOUD_USE_GRPC_JS) {
-  process.exit(0);
-}
-
 import {BigQuery} from '@google-cloud/bigquery';
-import {ServiceObject} from '@google-cloud/common';
 import {PubSub} from '@google-cloud/pubsub';
 import {Storage} from '@google-cloud/storage';
 import * as assert from 'assert';
@@ -62,39 +57,6 @@ describe('Logging', () => {
   after(async () => {
     await Promise.all(
         [deleteBuckets(), deleteDatasets(), deleteTopics(), deleteSinks()]);
-
-    async function deleteBuckets() {
-      const [buckets] = await storage.getBuckets({
-        prefix: TESTS_PREFIX,
-      });
-      return Promise.all(buckets.map(async bucket => {
-        await bucket.deleteFiles();
-        await bucket.delete();
-      }));
-    }
-
-    async function deleteDatasets() {
-      await getAndDelete(bigQuery.getDatasets.bind(bigQuery));
-    }
-
-    async function deleteTopics() {
-      await getAndDelete(pubsub.getTopics.bind(pubsub));
-    }
-
-    async function deleteSinks() {
-      await getAndDelete(logging.getSinks.bind(logging));
-    }
-
-    async function getAndDelete(method: Function) {
-      const [objects] = await method();
-      return Promise.all(
-          objects
-              .filter(
-                  (o: ServiceObject) =>
-                      // tslint:disable-next-line no-any
-                  ((o as any).name || o.id).indexOf(TESTS_PREFIX) === 0)
-              .map((o: ServiceObject) => o.delete()));
-    }
   });
 
   describe('sinks', () => {
@@ -498,5 +460,65 @@ describe('Logging', () => {
 
   function generateName() {
     return TESTS_PREFIX + uuid.v1();
+  }
+  async function deleteBuckets() {
+    const [buckets] = await storage.getBuckets({
+      prefix: TESTS_PREFIX,
+    });
+    const bucketsToDelete = buckets.filter(b => {
+      const expiration = Date.now() - 60 * 60 * 1000;
+      const timeCreated = Date.parse(b.metadata.timeCreated);
+      return timeCreated < expiration;
+    });
+    console.log(`Cleaning up ${bucketsToDelete.length} buckets...`);
+    return Promise.all(bucketsToDelete.map(async bucket => {
+      await bucket.deleteFiles();
+      await bucket.delete();
+    }));
+  }
+
+  async function deleteDatasets() {
+    const [datasets] = await bigQuery.getDatasets();
+    let datasetsToDelete = datasets.filter(ds => {
+      return ds.id!.indexOf(TESTS_PREFIX) > -1;
+    });
+    datasetsToDelete = await Promise.all(datasetsToDelete.map(async ds => {
+      await ds.get();
+      return ds;
+    }));
+    datasetsToDelete = datasetsToDelete.filter(ds => {
+      const expiration = Date.now() - 60 * 60 * 1000;
+      const timeCreated = ds.metadata.creationTime;
+      return timeCreated < expiration;
+    });
+    console.log(`Deleting ${datasetsToDelete.length} datasets...`);
+    await Promise.all(datasetsToDelete.map(ds => ds.delete()));
+  }
+
+  async function deleteTopics() {
+    // TODO(beckwith): There is no readily available metadata for the creation
+    // time of a topic. Need to figure out how to protect these from early
+    // deleting to avoid race conditions.
+    const [topics] = await pubsub.getTopics();
+    const topicsToDelete = topics.filter(topic => {
+      return topic.name.indexOf(TESTS_PREFIX) > -1;
+    });
+    console.log(`Deleting ${topicsToDelete.length} topics...`);
+    await Promise.all(topicsToDelete.map(topic => topic.delete()));
+  }
+
+  async function deleteSinks() {
+    const [sinks] = await logging.getSinks();
+    let sinksToDelete = sinks.filter(sink => {
+      return sink.name.indexOf(TESTS_PREFIX) > -1;
+    });
+    sinksToDelete = sinks.filter(sink => {
+      const expiration = Date.now() - 60 * 60 * 1000;
+      // tslint:disable-next-line no-any
+      const timeCreated = Date.parse((sink!.metadata as any).createTime);
+      return timeCreated < expiration;
+    });
+    console.log(`Deleting ${sinksToDelete.length} sinks...`);
+    await Promise.all(sinksToDelete.map(sink => sink.delete()));
   }
 });


### PR DESCRIPTION
The system tests are trying to delete all buckets, datasets, topics, and sinks that match a given name pattern.  If the system tests run at the same time, this leads to weird errors and conflicts.  This PR tries to fix that :)