### PR TITLE
Release @google-cloud/logging v4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://www.npmjs.com/package/nodejs-logging?activeTab=versions
 
+## v4.5.1
+
+03-18-2019 19:32 PDT
+
+### Bug Fixes
+- fix(ts): do not require storage/pubsub types, add install test ([#430](https://github.com/googleapis/nodejs-logging/pull/430))
+
 ## v4.5.0
 
 03-13-2019 22:25 PDT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "mocha system-test --timeout 60000"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.5.0",
+    "@google-cloud/logging": "^4.5.1",
     "@google-cloud/storage": "^2.0.2",
     "express": "^4.16.3",
     "fluent-logger": "^3.0.0",


### PR DESCRIPTION
This pull request was generated using releasetool.