### PR TITLE
chore: use new GCF env vars in descriptor

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -37,6 +37,11 @@ function zoneFromQualifiedZone(qualified: string): string|undefined {
  * @returns {object}
  */
 export function getCloudFunctionDescriptor() {
+  /**
+   * In GCF versions after Node 8, K_SERVICE is the preferred way to
+   * get the function name and GOOGLE_CLOUD_REGION is the preferred way
+   * to get the region.
+   */
   return {
     type: 'cloud_function',
     labels: {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -40,8 +40,8 @@ export function getCloudFunctionDescriptor() {
   return {
     type: 'cloud_function',
     labels: {
-      function_name: process.env.FUNCTION_NAME,
-      region: process.env.FUNCTION_REGION,
+      function_name: process.env.K_SERVICE || process.env.FUNCTION_NAME,
+      region: process.env.GOOGLE_CLOUD_REGION || process.env.FUNCTION_REGION,
     },
   };
 }

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -98,18 +98,34 @@ describe('metadata', () => {
     const K_SERVICE = 'k-service';
     const GOOGLE_CLOUD_REGION = 'google-cloud-region';
 
-    beforeEach(() => {
-      process.env.FUNCTION_NAME = FUNCTION_NAME;
-      process.env.FUNCTION_REGION = FUNCTION_REGION;
-      delete process.env.K_SERVICE;
-      delete process.env.GOOGLE_CLOUD_REGION;
+    const TARGET_KEYS = [
+      'FUNCTION_NAME', 'FUNCTION_REGION', 'K_SERVICE', 'GOOGLE_CLOUD_REGION'
+    ];
+    const INITIAL_ENV: {[key: string]: string|undefined} = {};
+
+    before(() => {
+      for (const key of TARGET_KEYS) {
+        INITIAL_ENV[key] = process.env[key];
+      }
     });
 
-    afterEach(() => {
-      delete process.env.FUNCTION_NAME;
-      delete process.env.FUNCTION_REGION;
-      delete process.env.K_SERVICE;
-      delete process.env.GOOGLE_CLOUD_REGION;
+    after(() => {
+      for (const key of TARGET_KEYS) {
+        const val = INITIAL_ENV[key];
+        if (val === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = val;
+        }
+      }
+    });
+
+    beforeEach(() => {
+      for (const key of TARGET_KEYS) {
+        delete process.env[key];
+      }
+      process.env.FUNCTION_NAME = FUNCTION_NAME;
+      process.env.FUNCTION_REGION = FUNCTION_REGION;
     });
 
     it('should return the correct primary descriptor', () => {

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -95,12 +95,37 @@ describe('metadata', () => {
     const FUNCTION_NAME = 'function-name';
     const FUNCTION_REGION = 'function-region';
 
+    const K_SERVICE = 'k-service';
+    const GOOGLE_CLOUD_REGION = 'google-cloud-region';
+
     beforeEach(() => {
       process.env.FUNCTION_NAME = FUNCTION_NAME;
       process.env.FUNCTION_REGION = FUNCTION_REGION;
+      delete process.env.K_SERVICE;
+      delete process.env.GOOGLE_CLOUD_REGION;
     });
 
-    it('should return the correct descriptor', () => {
+    afterEach(() => {
+      delete process.env.FUNCTION_NAME;
+      delete process.env.FUNCTION_REGION;
+      delete process.env.K_SERVICE;
+      delete process.env.GOOGLE_CLOUD_REGION;
+    });
+
+    it('should return the correct primary descriptor', () => {
+      process.env.K_SERVICE = K_SERVICE;
+      process.env.GOOGLE_CLOUD_REGION = GOOGLE_CLOUD_REGION;
+
+      assert.deepStrictEqual(metadata.getCloudFunctionDescriptor(), {
+        type: 'cloud_function',
+        labels: {
+          function_name: K_SERVICE,
+          region: GOOGLE_CLOUD_REGION,
+        },
+      });
+    });
+
+    it('should return the correct fallback descriptor', () => {
       assert.deepStrictEqual(metadata.getCloudFunctionDescriptor(), {
         type: 'cloud_function',
         labels: {


### PR DESCRIPTION
The `K_SERVICE` and `GOOGLE_CLOUD_REGION` env vars are the
preferred way of getting function name and region information
going forward.