### PR TITLE
Release @google-cloud/logging v4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 [1]: https://www.npmjs.com/package/nodejs-logging?activeTab=versions
 
+## v4.5.2
+
+04-11-2019 14:26 PDT
+
+This release has minor bug fixes:
+
+- fix(types): improve types for LogEntry ([#448](https://github.com/googleapis/nodejs-logging/pull/448))
+- fix: include 'x-goog-request-params' header in requests ([#439](https://github.com/googleapis/nodejs-logging/pull/439))
+
 ## v4.5.1
 
 03-18-2019 19:32 PDT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging",
   "description": "Stackdriver Logging Client Library for Node.js",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "mocha --timeout 60000"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.5.1",
+    "@google-cloud/logging": "^4.5.2",
     "@google-cloud/storage": "^2.0.2",
     "express": "^4.16.3",
     "fluent-logger": "^3.0.0",


### PR DESCRIPTION
This pull request was generated using releasetool.