### PR TITLE
refactor: sink.ts to async-first

### DIFF
--- a/src/sink.ts
+++ b/src/sink.ts
@@ -153,9 +153,8 @@ class Sink {
   delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   async delete(gaxOptions?: CallOptions|
                DeleteCallback): Promise<DeleteResponse> {
-    this.logging.projectId = await this.logging.auth.getProjectId();
-    this.formattedName_ =
-        'projects/' + this.logging.projectId + '/sinks/' + this.name;
+    const projectId = await this.logging.auth.getProjectId();
+    this.formattedName_ = 'projects/' + projectId + '/sinks/' + this.name;
     const reqOpts = {
       sinkName: this.formattedName_,
     };
@@ -208,9 +207,8 @@ class Sink {
   getMetadata(gaxOptions: CallOptions, callback: SinkMetadataCallback): void;
   async getMetadata(gaxOptions?: CallOptions|
                     SinkMetadataCallback): Promise<SinkMetadataResponse> {
-    this.logging.projectId = await this.logging.auth.getProjectId();
-    this.formattedName_ =
-        'projects/' + this.logging.projectId + '/sinks/' + this.name;
+    const projectId = await this.logging.auth.getProjectId();
+    this.formattedName_ = 'projects/' + projectId + '/sinks/' + this.name;
     const reqOpts = {
       sinkName: this.formattedName_,
     };

--- a/src/sink.ts
+++ b/src/sink.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import * as common from '@google-cloud/common-grpc';
-import {promisifyAll} from '@google-cloud/promisify';
+import {callbackifyAll, promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
 import {CreateSinkCallback, CreateSinkRequest, DeleteCallback, DeleteResponse, Logging, LogSink} from '.';
@@ -104,9 +103,8 @@ class Sink {
    */
   create(config: CreateSinkRequest): Promise<[Sink, LogSink]>;
   create(config: CreateSinkRequest, callback: CreateSinkCallback): void;
-  create(config: CreateSinkRequest, callback?: CreateSinkCallback):
-      Promise<[Sink, LogSink]>|void {
-    this.logging.createSink(this.name, config, callback!);
+  create(config: CreateSinkRequest): Promise<[Sink, LogSink]> {
+    return this.logging.createSink(this.name, config);
   }
 
   /**
@@ -153,23 +151,16 @@ class Sink {
   delete(gaxOptions?: CallOptions): Promise<DeleteResponse>;
   delete(callback: DeleteCallback): void;
   delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
-  delete(gaxOptions?: CallOptions|DeleteCallback, callback?: DeleteCallback):
-      Promise<DeleteResponse>|void {
-    if (typeof gaxOptions === 'function') {
-      callback = gaxOptions as DeleteCallback;
-      gaxOptions = {};
-    }
+  async delete(gaxOptions?: CallOptions|
+               DeleteCallback): Promise<DeleteResponse> {
+    this.logging.projectId = await this.logging.auth.getProjectId();
+    this.formattedName_ =
+        'projects/' + this.logging.projectId + '/sinks/' + this.name;
     const reqOpts = {
       sinkName: this.formattedName_,
     };
-    this.logging.request(
-        {
-          client: 'ConfigServiceV2Client',
-          method: 'deleteSink',
-          reqOpts,
-          gaxOpts: gaxOptions as CallOptions,
-        },
-        callback);
+    return this.logging.configService.deleteSink(
+        reqOpts, gaxOptions as CallOptions);
   }
 
   /**
@@ -215,30 +206,18 @@ class Sink {
   getMetadata(gaxOptions?: CallOptions): Promise<SinkMetadataResponse>;
   getMetadata(callback: SinkMetadataCallback): void;
   getMetadata(gaxOptions: CallOptions, callback: SinkMetadataCallback): void;
-  getMetadata(
-      gaxOptions?: CallOptions|SinkMetadataCallback,
-      callback?: SinkMetadataCallback): Promise<SinkMetadataResponse>|void {
-    const self = this;
-    if (typeof gaxOptions === 'function') {
-      callback = gaxOptions;
-      gaxOptions = {};
-    }
+  async getMetadata(gaxOptions?: CallOptions|
+                    SinkMetadataCallback): Promise<SinkMetadataResponse> {
+    this.logging.projectId = await this.logging.auth.getProjectId();
+    this.formattedName_ =
+        'projects/' + this.logging.projectId + '/sinks/' + this.name;
     const reqOpts = {
       sinkName: this.formattedName_,
     };
-    this.logging.request<LogSink>(
-        {
-          client: 'ConfigServiceV2Client',
-          method: 'getSink',
-          reqOpts,
-          gaxOpts: gaxOptions,
-        },
-        (...args) => {
-          if (args[1]) {
-            self.metadata = args[1];
-          }
-          callback!.apply(null, args);
-        });
+
+    [this.metadata] = await this.logging.configService.getSink(
+        reqOpts, gaxOptions as CallOptions);
+    return [this.metadata!];
   }
 
   /**
@@ -279,13 +258,12 @@ class Sink {
    */
   setFilter(filter: string): Promise<SinkMetadataResponse>;
   setFilter(filter: string, callback: SinkMetadataCallback): void;
-  setFilter(filter: string, callback?: SinkMetadataCallback):
-      Promise<SinkMetadataResponse>|void {
-    this.setMetadata(
+  setFilter(filter: string): Promise<SinkMetadataResponse> {
+    return this.setMetadata(
         {
           filter,
         },
-        callback!);
+    );
   }
 
   /**
@@ -336,43 +314,25 @@ class Sink {
    */
   setMetadata(metadata: SetSinkMetadata): Promise<SinkMetadataResponse>;
   setMetadata(metadata: SetSinkMetadata, callback: SinkMetadataCallback): void;
-  setMetadata(metadata: SetSinkMetadata, callback?: SinkMetadataCallback):
-      Promise<SinkMetadataResponse>|void {
-    const self = this;
-    callback = callback || common.util.noop;
-    this.getMetadata((err, currentMetadata) => {
-      if (err) {
-        callback!(err);
-        return;
-      }
-      const reqOpts = {
-        sinkName: self.formattedName_,
-        sink: extend({}, currentMetadata, metadata),
-      };
-      delete reqOpts.sink.gaxOptions;
-      self.logging.request(
-          {
-            client: 'ConfigServiceV2Client',
-            method: 'updateSink',
-            reqOpts,
-            gaxOpts: metadata.gaxOptions,
-          },
-          (...args) => {
-            if (args[1]) {
-              self.metadata = args[1];
-            }
-            callback!.apply(null, args);
-          });
-    });
+  async setMetadata(metadata: SetSinkMetadata): Promise<SinkMetadataResponse> {
+    const [currentMetadata] = await this.getMetadata();
+    const reqOpts = {
+      sinkName: this.formattedName_,
+      sink: extend({}, currentMetadata, metadata),
+    };
+    delete reqOpts.sink.gaxOptions;
+    [this.metadata] = await this.logging.configService.updateSink(
+        reqOpts, metadata.gaxOptions);
+    return [this.metadata!];
   }
 }
 
 /*! Developer Documentation
  *
- * All async methods (except for streams) will return a Promise in the event
- * that a callback is omitted.
+ * All async methods (except for streams) will call a callbakc in the event
+ * that a callback is provided.
  */
-promisifyAll(Sink);
+callbackifyAll(Sink);
 
 /**
  * Reference to the {@link Sink} class.

--- a/test/sink.ts
+++ b/test/sink.ts
@@ -15,16 +15,16 @@
  */
 
 import {util} from '@google-cloud/common-grpc';
-import * as promisify from '@google-cloud/promisify';
+import * as callbackify from '@google-cloud/promisify';
 import * as assert from 'assert';
 import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 
-let promisifed = false;
-const fakePromisify = extend({}, promisify, {
-  promisifyAll(c) {
+let callbackified = false;
+const fakeCallbackify = extend({}, callbackify, {
+  callbackifyAll(c) {
     if (c.name === 'Sink') {
-      promisifed = true;
+      callbackified = true;
     }
   },
 });
@@ -34,15 +34,19 @@ describe('Sink', () => {
   let Sink: any;
   let sink;
 
+  const PROJECT_ID = 'project-id';
+
   const LOGGING = {
     createSink: util.noop,
-    projectId: 'project-id',
+    projectId: '{{projectId}}',
+    auth: util.noop,
+    configService: util.noop,
   };
   const SINK_NAME = 'sink-name';
 
   before(() => {
     Sink = proxyquire('../src/sink', {
-             '@google-cloud/promisify': fakePromisify,
+             '@google-cloud/promisify': fakeCallbackify,
            }).Sink;
   });
 
@@ -52,7 +56,7 @@ describe('Sink', () => {
 
   describe('instantiation', () => {
     it('should promisify all the things', () => {
-      assert(promisifed);
+      assert(callbackified);
     });
 
     it('should localize Logging instance', () => {
@@ -71,115 +75,103 @@ describe('Sink', () => {
   });
 
   describe('create', () => {
-    it('should call parent createSink', done => {
+    it('should call parent createSink', async () => {
       const config = {};
 
-      sink.logging.createSink = (name, config_, callback) => {
+      sink.logging.createSink = async (name, config_) => {
         assert.strictEqual(name, sink.name);
         assert.strictEqual(config_, config);
-        callback();  // done()
       };
 
-      sink.create(config, done);
+      await sink.create(config);
     });
   });
 
   describe('delete', () => {
-    it('should accept gaxOptions', done => {
-      sink.logging.request = (config, callback) => {
-        assert.strictEqual(config.client, 'ConfigServiceV2Client');
-        assert.strictEqual(config.method, 'deleteSink');
-
-        assert.deepStrictEqual(config.reqOpts, {
+    it('should execute gax method', async () => {
+      sink.logging.auth.getProjectId = async () => PROJECT_ID;
+      sink.logging.configService.deleteSink = async (reqOpts, gaxOpts) => {
+        assert.deepStrictEqual(reqOpts, {
           sinkName: sink.formattedName_,
         });
-
-        assert.deepStrictEqual(config.gaxOpts, {});
-
-        callback();  // done()
+        assert.strictEqual(gaxOpts, undefined);
       };
 
-      sink.delete(done);
+      await sink.delete();
     });
 
-    it('should accept gaxOptions', done => {
+    it('should accept gaxOptions', async () => {
       const gaxOptions = {};
 
-      sink.logging.request = config => {
-        assert.strictEqual(config.gaxOpts, gaxOptions);
-        done();
+      sink.logging.getProjectId = async () => {};
+      sink.logging.configService.deleteSink = async (reqOpts, gaxOpts) => {
+        assert.deepStrictEqual(gaxOpts, gaxOptions);
       };
 
-      sink.delete(gaxOptions, assert.ifError);
+      await sink.delete(gaxOptions);
     });
   });
 
   describe('getMetadata', () => {
-    it('should make correct request', done => {
-      sink.logging.request = config => {
-        assert.strictEqual(config.client, 'ConfigServiceV2Client');
-        assert.strictEqual(config.method, 'getSink');
-
-        assert.deepStrictEqual(config.reqOpts, {
+    beforeEach(() => {
+      sink.logging.auth.getProjectId = async () => PROJECT_ID;
+    });
+    it('should execute gax method', async () => {
+      sink.logging.configService.getSink = async (reqOpts, gaxOpts) => {
+        assert.deepStrictEqual(reqOpts, {
           sinkName: sink.formattedName_,
         });
-
-        assert.deepStrictEqual(config.gaxOpts, {});
-
-        done();
+        assert.strictEqual(gaxOpts, undefined);
+        return [];
       };
 
-      sink.getMetadata(assert.ifError);
+      await sink.getMetadata();
     });
 
-    it('should accept gaxOptions', done => {
+    it('should accept gaxOptions', async () => {
       const gaxOptions = {};
 
-      sink.logging.request = config => {
-        assert.strictEqual(config.gaxOpts, gaxOptions);
-        done();
+      sink.logging.configService.getSink = async (reqOpts, gaxOpts) => {
+        assert.deepStrictEqual(gaxOpts, gaxOptions);
+        return [];
       };
 
-      sink.delete(gaxOptions, assert.ifError);
+      await sink.getMetadata(gaxOptions);
     });
 
-    it('should update metadata', done => {
+    it('should update metadata', async () => {
       const metadata = {};
 
-      sink.logging.request = (config, callback) => {
-        callback(null, metadata);
+      sink.logging.configService.getSink = async (reqOpts, gaxOpts) => {
+        return [metadata];
       };
 
-      sink.getMetadata(() => {
-        assert.strictEqual(sink.metadata, metadata);
-        done();
-      });
+      await sink.getMetadata();
+      assert.strictEqual(sink.metadata, metadata);
     });
 
-    it('should execute callback with original arguments', done => {
+    it('should return original arguments', async () => {
       const ARGS = [{}, {}, {}];
 
-      sink.logging.request = (config, callback) => {
-        callback.apply(null, ARGS);
+      sink.logging.configService.getSink = async (reqOpts, gaxOpts) => {
+        return [ARGS];
       };
 
-      sink.getMetadata((...args) => {
-        assert.deepStrictEqual(args, ARGS);
-        done();
-      });
+      const [args] = await sink.getMetadata();
+      assert.deepStrictEqual(args, ARGS);
     });
   });
 
   describe('setFilter', () => {
     const FILTER = 'filter';
 
-    it('should call set metadata', done => {
-      sink.setMetadata = (metadata, callback) => {
+    it('should call set metadata', async () => {
+      sink.setMetadata = async (metadata) => {
         assert.strictEqual(metadata.filter, FILTER);
-        callback();  // done()
+        return [];
       };
 
-      sink.setFilter(FILTER, done);
+      await sink.setFilter(FILTER);
     });
   });
 
@@ -187,94 +179,90 @@ describe('Sink', () => {
     const METADATA = {a: 'b', c: 'd'};
 
     beforeEach(() => {
-      sink.getMetadata = (callback) => {
-        callback(null, METADATA);
+      sink.getMetadata = async () => {
+        return [METADATA];
       };
+
+      sink.logging.auth.getProjectId = async () => PROJECT_ID;
     });
 
-    it('should refresh the metadata', done => {
+    it('should refresh the metadata', async () => {
       sink.getMetadata = () => {
-        done();
+        return [];
       };
 
-      sink.setMetadata(METADATA, assert.ifError);
+      sink.logging.configService.updateSink = async (reqOpts, gaxOpts) => {
+        return [METADATA];
+      };
+
+      assert.strictEqual(sink.metadata, undefined);
+      await sink.setMetadata(METADATA);
+      assert.deepStrictEqual(sink.metadata, METADATA);
     });
 
-    it('should exec callback with error from refresh', done => {
+    it('should throw the error from refresh', () => {
       const error = new Error('Error.');
 
-      sink.getMetadata = (callback) => {
-        callback(error);
+      sink.getMetadata = async () => {
+        throw error;
       };
 
-      sink.setMetadata(METADATA, (err) => {
-        assert.strictEqual(err, error);
-        done();
-      });
+      sink.setMetadata(METADATA).then(
+          util.noop, (err) => assert.strictEqual(err, error));
     });
 
-    it('should make the correct request', done => {
+    it('should execute gax method', async () => {
       const currentMetadata = {a: 'a', e: 'e'};
 
-      sink.getMetadata = (callback) => {
-        callback(null, currentMetadata);
+      sink.getMetadata = async () => {
+        return [currentMetadata];
       };
 
-      sink.logging.request = (config) => {
-        assert.strictEqual(config.client, 'ConfigServiceV2Client');
-        assert.strictEqual(config.method, 'updateSink');
-
-        assert.deepStrictEqual(config.reqOpts, {
+      sink.logging.configService.updateSink = async (reqOpts, gaxOpts) => {
+        assert.deepStrictEqual(reqOpts, {
           sinkName: sink.formattedName_,
           sink: extend({}, currentMetadata, METADATA),
         });
-
-        assert.strictEqual(config.gaxOpts, undefined);
-
-        done();
+        assert.strictEqual(gaxOpts, undefined);
+        return [];
       };
 
-      sink.setMetadata(METADATA, assert.ifError);
+      await sink.setMetadata(METADATA);
     });
 
-    it('should accept gaxOptions', done => {
+    it('should accept gaxOptions', async () => {
       const metadata = extend({}, METADATA, {
         gaxOptions: {},
       });
 
-      sink.logging.request = (config) => {
-        assert.strictEqual(config.reqOpts.sink.gaxOptions, undefined);
-        assert.strictEqual(config.gaxOpts, metadata.gaxOptions);
-        done();
+      sink.logging.configService.updateSink = async (reqOpts, gaxOpts) => {
+        assert.strictEqual(reqOpts.sink.gaxOptions, undefined);
+        assert.strictEqual(gaxOpts, metadata.gaxOptions);
+        return [];
       };
-
-      sink.setMetadata(metadata, assert.ifError);
+      await sink.setMetadata(metadata);
     });
 
-    it('should update metadata', done => {
+    it('should update metadata', async () => {
       const metadata = {};
 
-      sink.logging.request = (config, callback) => {
-        callback(null, metadata);
+      sink.logging.configService.updateSink = async (reqOpts, gaxOpts) => {
+        return [metadata];
       };
 
-      sink.setMetadata(metadata, () => {
-        assert.strictEqual(sink.metadata, metadata);
-        done();
-      });
+      await sink.setMetadata(metadata);
+      assert.strictEqual(sink.metadata, metadata);
     });
 
-    it('should execute callback with original arguments', done => {
+    it('should return callback with original arguments', async () => {
       const ARGS = [{}, {}, {}];
 
-      sink.logging.request = (config, callback) => {
-        callback.apply(null, ARGS);
+      sink.logging.configService.updateSink = async (reqOpts, gaxOpts) => {
+        return [ARGS];
       };
 
-      sink.setMetadata(METADATA, (...args) => {
-        assert.deepStrictEqual(args, ARGS);
-        done();
-      });
+      const [args] = await sink.setMetadata(METADATA);
+      assert.deepStrictEqual(args, ARGS);
     });
   });
 });


### PR DESCRIPTION
Towards #390

Refactor: `sink.ts` to async-first

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

