### PR TITLE
fix: add test for x-goog-api-client header

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/common-grpc": "^1.0.0",
+    "@google-cloud/common-grpc": "^1.0.5",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
@@ -69,6 +69,7 @@
     "pumpify": "^2.0.0",
     "snakecase-keys": "^3.0.0",
     "stream-events": "^1.0.4",
+    "teeny-request": "^5.2.1",
     "through2": "^3.0.0",
     "type-fest": "^0.7.0"
   },
@@ -100,6 +101,7 @@
     "google-proto-files": "^1.0.0",
     "grpc": "^1.22.2",
     "gts": "^1.0.0",
+    "http2spy": "^1.1.0",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.6.2",
     "jsdoc-fresh": "^1.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
 import * as gax from 'google-gax';
 import {ClientReadableStream} from 'grpc';
-import * as request from 'request';
+import {Response} from 'teeny-request';
 
 const pumpify = require('pumpify');
 import * as streamEvents from 'stream-events';
@@ -84,11 +84,7 @@ export interface CreateSinkRequest {
 }
 
 export interface CreateSinkCallback {
-  (
-    err: Error | null,
-    sink?: Sink | null,
-    resp?: LogSink | request.Response
-  ): void;
+  (err: Error | null, sink?: Sink | null, resp?: LogSink | Response): void;
 }
 
 export type GetEntriesResponse = [

--- a/src/log.ts
+++ b/src/log.ts
@@ -19,7 +19,7 @@ import {callbackifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
-import {Response} from 'request';
+import {Response} from 'teeny-request';
 
 import {google} from '../proto/logging';
 

--- a/src/v2/config_service_v2_client.js
+++ b/src/v2/config_service_v2_client.js
@@ -82,7 +82,7 @@ class ConfigServiceV2Client {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
+      `gl-node/${process.versions.node}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gax.version}`,
       `gapic/${VERSION}`,

--- a/src/v2/logging_service_v2_client.js
+++ b/src/v2/logging_service_v2_client.js
@@ -82,7 +82,7 @@ class LoggingServiceV2Client {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
+      `gl-node/${process.versions.node}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gax.version}`,
       `gapic/${VERSION}`,

--- a/src/v2/metrics_service_v2_client.js
+++ b/src/v2/metrics_service_v2_client.js
@@ -81,7 +81,7 @@ class MetricsServiceV2Client {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
+      `gl-node/${process.versions.node}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gax.version}`,
       `gapic/${VERSION}`,

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -220,7 +220,9 @@ describe('Logging', () => {
     const logs: any[] = [];
 
     function getTestLog(loggingInstnce = null) {
-      const log = (loggingInstnce || logging).log(`system-test-logs-${uuid.v4()}`);
+      const log = (loggingInstnce || logging).log(
+        `system-test-logs-${uuid.v4()}`
+      );
       logs.push(log);
 
       const logEntries = [

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -28,8 +28,7 @@ import * as nock from 'nock';
 import {Duplex} from 'stream';
 import * as uuid from 'uuid';
 import * as http2spy from 'http2spy';
-const {Logging} = http2spy.require(require.resolve('../src'));
-import {Sink} from '../src';
+import {Logging, Sink} from '../src';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock(HOST_ADDRESS)
@@ -220,8 +219,8 @@ describe('Logging', () => {
     // tslint:disable-next-line no-any
     const logs: any[] = [];
 
-    function getTestLog() {
-      const log = logging.log(`system-test-logs-${uuid.v4()}`);
+    function getTestLog(loggingInstnce = null) {
+      const log = (loggingInstnce || logging).log(`system-test-logs-${uuid.v4()}`);
       logs.push(log);
 
       const logEntries = [
@@ -582,7 +581,8 @@ describe('Logging', () => {
     });
 
     it('should populate x-goog-api-client header', async () => {
-      const {log, logEntries} = getTestLog();
+      const {Logging} = http2spy.require(require.resolve('../src'));
+      const {log, logEntries} = getTestLog(new Logging());
       await log.write(logEntries[0], options);
       assert.ok(
         /gl-node\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gapic\/[0-9]+\.[\w.-]+ gccl\/[0-9]+\.[\w.-]+/.test(


### PR DESCRIPTION
adds a test for the `x-goog-api-client-header` being populated, the fix for `process.version` has already been landed and just needs to be deployed (I made the change manually so that this passes).