### PR TITLE
fix: add missing function overload

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -190,6 +190,7 @@ class Log implements LogSeverityFunctions {
    *   const apiResponse = data[0];
    * });
    */
+  critical(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
   critical(
     entry: Entry | Entry[],
     options: WriteOptions,

--- a/src/log.ts
+++ b/src/log.ts
@@ -190,7 +190,10 @@ class Log implements LogSeverityFunctions {
    *   const apiResponse = data[0];
    * });
    */
-  critical(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  critical(
+    entry: Entry | Entry[],
+    options?: WriteOptions
+  ): Promise<ApiResponse>;
   critical(
     entry: Entry | Entry[],
     options: WriteOptions,


### PR DESCRIPTION
There is a function overload missing in `log.ts` for the function `critical(...)` resulting in a compiler error if `critical` is used as an await function.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
