### PR TITLE
fix(deps): gcp-metadata now handles ENETUNREACH

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "arrify": "^2.0.0",
     "eventid": "^0.1.2",
     "extend": "^3.0.2",
-    "gcp-metadata": "^3.0.0",
+    "gcp-metadata": "^3.1.0",
     "google-auth-library": "^5.2.2",
     "google-gax": "^1.6.3",
     "is": "^3.2.1",


### PR DESCRIPTION
Fixes #587 