### PR TITLE
fix(deps): pin to newer version of grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/common-grpc": "^1.0.5",
+    "@google-cloud/common-grpc": "^1.0.6",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",


### PR DESCRIPTION
This gets us on `@grpc/gprc-js@0.6.7`.
