### PR TITLE
feat: introduce maxEntrySize, for enabling error message truncation

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -895,16 +895,15 @@ class Log implements LogSeverityFunctions {
       } else {
         // Stackdriver Log Viewer picks up the summary line from the
         // 'message' field.
-        let text: string | null | undefined;
         if (
           entry.jsonPayload &&
           entry.jsonPayload.fields &&
-          entry.jsonPayload.fields.message
+          entry.jsonPayload.fields.message &&
+          entry.jsonPayload.fields.message.stringValue
         ) {
-          text = entry.jsonPayload.fields.message.stringValue;
-        }
-        if (text) {
-          entry!.jsonPayload!.fields!.message.stringValue = text.slice(
+          const text: string | null | undefined =
+            entry.jsonPayload.fields.message.stringValue;
+          entry.jsonPayload.fields.message.stringValue = text.slice(
             0,
             Math.max(text.length - delta, 0)
           );

--- a/src/log.ts
+++ b/src/log.ts
@@ -909,7 +909,6 @@ class Log implements LogSeverityFunctions {
             Math.max(text.length - delta, 0)
           );
         }
-        console.info(JSON.stringify(entry));
       }
     });
   }

--- a/src/log.ts
+++ b/src/log.ts
@@ -24,7 +24,7 @@ import {Response} from 'teeny-request';
 import {google} from '../proto/logging';
 
 import {GetEntriesCallback, GetEntriesResponse, Logging} from '.';
-import {Entry, LogEntry} from './entry';
+import {Entry, EntryJson, LogEntry} from './entry';
 import {getDefaultResource} from './metadata';
 
 const snakeCaseKeys = require('snakecase-keys');
@@ -44,6 +44,7 @@ export interface GetEntriesRequest {
 
 export interface LogOptions {
   removeCircular?: boolean;
+  maxEntrySize?: number; // see: https://cloud.google.com/logging/quotas
 }
 
 export type ApiResponse = [Response];
@@ -103,12 +104,14 @@ type LogSeverityFunctions = {
 class Log implements LogSeverityFunctions {
   formattedName_: string;
   removeCircular_: boolean;
+  maxEntrySize?: number;
   logging: Logging;
   name: string;
   constructor(logging: Logging, name: string, options?: LogOptions) {
     options = options || {};
     this.formattedName_ = Log.formatName_(logging.projectId, name);
     this.removeCircular_ = options.removeCircular === true;
+    this.maxEntrySize = options.maxEntrySize;
     this.logging = logging;
     /**
      * @name Log#name
@@ -828,6 +831,7 @@ class Log implements LogSeverityFunctions {
       } catch (err) {
         // Ignore errors (the API will speak up if it has an issue).
       }
+      self.truncateEntries(decoratedEntries);
       const projectId = await self.logging.auth.getProjectId();
       self.formattedName_ = Log.formatName_(projectId, self.name);
       const reqOpts = extend(
@@ -855,7 +859,7 @@ class Log implements LogSeverityFunctions {
    * @returns {object[]} Serialized entries.
    * @throws if there is an error during serialization.
    */
-  decorateEntries_(entries: Entry[]) {
+  decorateEntries_(entries: Entry[]): EntryJson[] {
     return entries.map(entry => {
       if (!(entry instanceof Entry)) {
         entry = this.entry(entry);
@@ -863,6 +867,50 @@ class Log implements LogSeverityFunctions {
       return entry.toJSON({
         removeCircular: this.removeCircular_,
       });
+    });
+  }
+
+  /**
+   * Truncate log entries at maxEntrySize, so that error is not thrown, see:
+   * https://cloud.google.com/logging/quotas
+   *
+   * @private
+   *
+   * @param {object|string} the JSON log entry.
+   * @returns {object|string} truncated JSON log entry.
+   */
+  private truncateEntries(entries: EntryJson[]) {
+    return entries.forEach(entry => {
+      if (this.maxEntrySize === undefined) return;
+
+      const payloadSize = JSON.stringify(entry).length;
+      if (payloadSize < this.maxEntrySize) return;
+
+      const delta = payloadSize - this.maxEntrySize;
+      if (entry.textPayload) {
+        entry.textPayload = entry.textPayload.slice(
+          0,
+          Math.max(entry.textPayload.length - delta, 0)
+        );
+      } else {
+        // Stackdriver Log Viewer picks up the summary line from the
+        // 'message' field.
+        let text: string | null | undefined;
+        if (
+          entry.jsonPayload &&
+          entry.jsonPayload.fields &&
+          entry.jsonPayload.fields.message
+        ) {
+          text = entry.jsonPayload.fields.message.stringValue;
+        }
+        if (text) {
+          entry!.jsonPayload!.fields!.message.stringValue = text.slice(
+            0,
+            Math.max(text.length - delta, 0)
+          );
+        }
+        console.info(JSON.stringify(entry));
+      }
     });
   }
 

--- a/test/log.ts
+++ b/test/log.ts
@@ -482,7 +482,7 @@ describe('Log', () => {
       await truncatingLogger.write(entry);
     });
 
-    it('should truncate object entry if maxEntrySize hit', async () => {
+    it('should truncate message field, on object entry, if maxEntrySize hit', async () => {
       const truncatingLogger = createLogger(200);
       const entry = new Entry(
         {},

--- a/test/log.ts
+++ b/test/log.ts
@@ -33,6 +33,7 @@ const fakeCallbackify = extend({}, callbackify, {
 
 import {Entry} from '../src';
 import {EntryJson} from '../src/entry';
+import {LogOptions} from '../src/log';
 
 const originalGetDefaultResource = async () => {
   return 'very-fake-resource';
@@ -76,6 +77,10 @@ describe('Log', () => {
   });
 
   beforeEach(() => {
+    log = createLogger();
+  });
+
+  function createLogger(maxEntrySize?: number) {
     assignSeverityToEntriesOverride = null;
 
     LOGGING = {
@@ -86,8 +91,13 @@ describe('Log', () => {
       auth: util.noop,
     };
 
-    log = new Log(LOGGING, LOG_NAME);
-  });
+    const options: LogOptions = {};
+    if (maxEntrySize) {
+      options.maxEntrySize = maxEntrySize;
+    }
+
+    return new Log(LOGGING, LOG_NAME, options);
+  }
 
   describe('instantiation', () => {
     it('should callbackify all the things', () => {
@@ -440,6 +450,57 @@ describe('Log', () => {
       log.logging.loggingService.writeLogEntries = (reqOpts, gaxOpts) => {};
 
       await log.write(ENTRY);
+    });
+
+    it('should not truncate entries by default', async () => {
+      const truncatingLogger = createLogger();
+      const entry = new Entry({}, 'hello world'.padEnd(300000, '.'));
+
+      truncatingLogger.logging.loggingService.writeLogEntries = (
+        reqOpts,
+        _gaxOpts
+      ) => {
+        assert.strictEqual(reqOpts.entries[0].textPayload.length, 300000);
+      };
+
+      await truncatingLogger.write(entry);
+    });
+
+    it('should truncate string entry if maxEntrySize hit', async () => {
+      const truncatingLogger = createLogger(200);
+      const entry = new Entry({}, 'hello world'.padEnd(2000, '.'));
+
+      truncatingLogger.logging.loggingService.writeLogEntries = (
+        reqOpts,
+        _gaxOpts
+      ) => {
+        const text = reqOpts.entries[0].textPayload;
+        assert.ok(text.startsWith('hello world'));
+        assert.ok(text.length < 300);
+      };
+
+      await truncatingLogger.write(entry);
+    });
+
+    it('should truncate object entry if maxEntrySize hit', async () => {
+      const truncatingLogger = createLogger(200);
+      const entry = new Entry(
+        {},
+        {
+          message: 'hello world'.padEnd(2000, '.'),
+        }
+      );
+
+      truncatingLogger.logging.loggingService.writeLogEntries = (
+        reqOpts,
+        _gaxOpts
+      ) => {
+        const text = reqOpts.entries[0].jsonPayload.fields.message.stringValue;
+        assert.ok(text.startsWith('hello world'));
+        assert.ok(text.length < 300);
+      };
+
+      await truncatingLogger.write(entry);
     });
   });
 

--- a/test/log.ts
+++ b/test/log.ts
@@ -453,17 +453,14 @@ describe('Log', () => {
     });
 
     it('should not truncate entries by default', async () => {
-      const truncatingLogger = createLogger();
+      const logger = createLogger();
       const entry = new Entry({}, 'hello world'.padEnd(300000, '.'));
 
-      truncatingLogger.logging.loggingService.writeLogEntries = (
-        reqOpts,
-        _gaxOpts
-      ) => {
+      logger.logging.loggingService.writeLogEntries = (reqOpts, _gaxOpts) => {
         assert.strictEqual(reqOpts.entries[0].textPayload.length, 300000);
       };
 
-      await truncatingLogger.write(entry);
+      await logger.write(entry);
     });
 
     it('should truncate string entry if maxEntrySize hit', async () => {


### PR DESCRIPTION
introduces the configuration setting `maxEntrySize` which, if set, will make a best effort to truncate text log entries, such that they don't result in an exception, see:

https://cloud.google.com/logging/quotas

_Note: as follow up, we should set this option to `256,000` on logging-bunyan, and logging-winston._

fixes #427
