### PR TITLE
fix: truncate additional fields set by winston/bunyan

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@google-cloud/promisify": "^1.0.0",
     "@opencensus/propagation-stackdriver": "0.0.17",
     "arrify": "^2.0.0",
+    "dot-prop": "^5.1.0",
     "eventid": "^0.1.2",
     "extend": "^3.0.2",
     "gcp-metadata": "^3.1.0",

--- a/test/log.ts
+++ b/test/log.ts
@@ -499,6 +499,34 @@ describe('Log', () => {
 
       await truncatingLogger.write(entry);
     });
+
+    it('should truncate stack trace', async () => {
+      const truncatingLogger = createLogger(300);
+      const entry = new Entry(
+        {},
+        {
+          message: 'hello world'.padEnd(2000, '.'),
+          metadata: {
+            stack: 'hello world'.padEnd(2000, '.'),
+          },
+        }
+      );
+
+      truncatingLogger.logging.loggingService.writeLogEntries = (
+        reqOpts,
+        _gaxOpts
+      ) => {
+        const message =
+          reqOpts.entries[0].jsonPayload.fields.message.stringValue;
+        const stack = reqOpts.entries[0].jsonPayload.fields.metadata
+          .structValue!.fields!.stack.stringValue;
+        assert.strictEqual(stack, '');
+        assert.ok(message.startsWith('hello world'));
+        assert.ok(message.length < 400);
+      };
+
+      await truncatingLogger.write(entry);
+    });
   });
 
   describe('severity shortcuts', () => {


### PR DESCRIPTION
our Winston and Bunyan loggers set a variety of additional fields that push us above the `256kb` log limit, I've abstracted the approach we use to allow a set of fields to be truncated ... using :stars: magic :stars:.
