### PR TITLE
refactor: reduce common dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,13 +69,11 @@
     "pumpify": "^2.0.0",
     "snakecase-keys": "^3.0.0",
     "stream-events": "^1.0.4",
-    "teeny-request": "^5.2.1",
     "through2": "^3.0.0",
     "type-fest": "^0.8.0"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^4.0.0",
-    "@google-cloud/nodejs-repo-tools": "^3.3.0",
     "@google-cloud/pubsub": "^1.0.0",
     "@google-cloud/storage": "^3.0.4",
     "@types/extend": "^3.0.0",
@@ -98,7 +96,6 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "google-proto-files": "^1.0.0",
-    "grpc": "^1.22.2",
     "gts": "^1.0.0",
     "http2spy": "^1.1.0",
     "intelli-espower-loader": "^1.0.1",

--- a/src/log.ts
+++ b/src/log.ts
@@ -15,13 +15,10 @@
  */
 
 import arrify = require('arrify');
-import {DeleteCallback} from '@google-cloud/common';
 import {callbackifyAll} from '@google-cloud/promisify';
 import * as dotProp from 'dot-prop';
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
-import {Response} from 'teeny-request';
-
 import {google} from '../proto/logging';
 
 import {GetEntriesCallback, GetEntriesResponse, Logging} from '.';
@@ -48,10 +45,13 @@ export interface LogOptions {
   maxEntrySize?: number; // see: https://cloud.google.com/logging/quotas
 }
 
-export type ApiResponse = [Response];
+// tslint:disable-next-line no-any
+export type Metadata = any;
+export type ApiResponse = [Metadata];
 export interface ApiResponseCallback {
-  (err: Error | null, apiResponse?: Response): void;
+  (err: Error | null, apiResponse?: Metadata): void;
 }
+export type DeleteCallback = ApiResponseCallback;
 
 export type MonitoredResource = google.api.IMonitoredResource;
 export interface WriteOptions {

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-if (process.env.GOOGLE_CLOUD_USE_GRPC_JS) {
-  process.exit(0);
-}
-
 import {BigQuery} from '@google-cloud/bigquery';
-import {ServiceObject} from '@google-cloud/common';
 import {PubSub} from '@google-cloud/pubsub';
 import {Storage} from '@google-cloud/storage';
 import * as assert from 'assert';
@@ -105,17 +100,14 @@ describe('Logging', () => {
       const [objects] = await method();
       return Promise.all(
         objects
-          .filter((o: ServiceObject) => {
-            // tslint:disable-next-line no-any
-            const name = (o as any).name || o.id;
-
+          .filter(o => {
+            const name = o.name || o.id;
             if (!name.startsWith(TESTS_PREFIX)) {
               return false;
             }
-
             return getDateFromGeneratedName(name) < oneHourAgo;
           })
-          .map((o: ServiceObject) => o.delete())
+          .map(o => o.delete())
       );
     }
   });

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   ObjectToStructConverter,
   ObjectToStructConverterConfig,

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {util} from '@google-cloud/common';
 import * as assert from 'assert';
 import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
@@ -25,7 +24,7 @@ let fakeEventIdNewOverride: Function | null;
 
 class FakeEventId {
   new() {
-    return (fakeEventIdNewOverride || util.noop).apply(null, arguments);
+    return (fakeEventIdNewOverride || (() => {})).apply(null, arguments);
   }
 }
 
@@ -166,7 +165,7 @@ describe('Entry', () => {
 
   describe('toJSON', () => {
     beforeEach(() => {
-      fakeObjToStruct = util.noop;
+      fakeObjToStruct = () => {};
     });
 
     it('should not modify the original instance', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -26,6 +26,7 @@ import {Logging as LOGGING} from '../src/index';
 const {v2} = require('../src');
 const PKG = require('../../package.json');
 
+const noop = () => {};
 let extended = false;
 const fakePaginator = {
   paginator: {
@@ -45,7 +46,7 @@ const fakePaginator = {
 
 let googleAuthOverride: Function | null;
 function fakeGoogleAuth() {
-  return (googleAuthOverride || util.noop).apply(null, arguments);
+  return (googleAuthOverride || noop).apply(null, arguments);
 }
 
 let isCustomTypeOverride: Function | null;
@@ -236,14 +237,14 @@ describe('Logging', () => {
 
     it('should throw if a name is not provided', () => {
       const error = new Error('A sink name must be provided.');
-      logging.createSink().then(util.noop, err => {
+      logging.createSink().then(noop, err => {
         assert.deepStrictEqual(err, error);
       });
     });
 
     it('should throw if a config object is not provided', () => {
       const error = new Error('A sink configuration object must be provided.');
-      logging.createSink(SINK_NAME).then(util.noop, err => {
+      logging.createSink(SINK_NAME).then(noop, err => {
         assert.deepStrictEqual(err, error);
       });
     });
@@ -360,7 +361,7 @@ describe('Logging', () => {
 
           logging
             .createSink(SINK_NAME, {})
-            .then(util.noop, err => assert.deepStrictEqual(err, error));
+            .then(noop, err => assert.deepStrictEqual(err, error));
         });
       });
 
@@ -512,9 +513,7 @@ describe('Logging', () => {
       });
 
       it('should reject promise with error', () => {
-        logging
-          .getEntries()
-          .then(util.noop, err => assert.strictEqual(err, error));
+        logging.getEntries().then(noop, err => assert.strictEqual(err, error));
       });
     });
 
@@ -772,7 +771,7 @@ describe('Logging', () => {
         };
         logging
           .getSinks(OPTIONS)
-          .then(util.noop, err => assert.strictEqual(err, error));
+          .then(noop, err => assert.strictEqual(err, error));
       });
     });
 
@@ -954,7 +953,7 @@ describe('Logging', () => {
       };
 
       logging.api[CONFIG.client] = {
-        [CONFIG.method]: util.noop,
+        [CONFIG.method]: noop,
       };
     });
 
@@ -990,7 +989,7 @@ describe('Logging', () => {
 
       it('should initiate and cache the client', () => {
         const fakeClient = {
-          [CONFIG.method]: util.noop,
+          [CONFIG.method]: noop,
         };
         fakeV2[CONFIG.client] = class {
           constructor(options) {
@@ -1029,7 +1028,7 @@ describe('Logging', () => {
 
             setImmediate(done);
 
-            return util.noop;
+            return noop;
           },
         };
 
@@ -1061,7 +1060,7 @@ describe('Logging', () => {
 
             setImmediate(done);
 
-            return util.noop;
+            return noop;
           },
         };
 
@@ -1198,7 +1197,7 @@ describe('Logging', () => {
         name: 'bucket-name',
         acl: {
           owners: {
-            addGroup: util.noop,
+            addGroup: noop,
           },
         },
       };
@@ -1228,7 +1227,7 @@ describe('Logging', () => {
       it('should return error', () => {
         logging
           .setAclForBucket_(CONFIG)
-          .then(util.noop, err => assert.deepStrictEqual(err, error));
+          .then(noop, err => assert.deepStrictEqual(err, error));
       });
     });
 
@@ -1278,7 +1277,7 @@ describe('Logging', () => {
         it('should reject with error', () => {
           logging
             .setAclForDataset_(CONFIG)
-            .then(util.noop, err => assert.deepStrictEqual(err, error));
+            .then(noop, err => assert.deepStrictEqual(err, error));
         });
       });
 
@@ -1326,7 +1325,7 @@ describe('Logging', () => {
           it('should reject with error', () => {
             logging
               .setAclForDataset_(CONFIG)
-              .then(util.noop, err => assert.deepStrictEqual(err, error));
+              .then(noop, err => assert.deepStrictEqual(err, error));
           });
         });
 
@@ -1361,8 +1360,8 @@ describe('Logging', () => {
       topic = {
         name: 'topic-name',
         iam: {
-          getPolicy: util.noop,
-          setPolicy: util.noop,
+          getPolicy: noop,
+          setPolicy: noop,
         },
       };
 
@@ -1385,7 +1384,7 @@ describe('Logging', () => {
         it('should throw error', () => {
           logging
             .setAclForTopic_(CONFIG)
-            .then(util.noop, err => assert.deepStrictEqual(err, error));
+            .then(noop, err => assert.deepStrictEqual(err, error));
         });
       });
 
@@ -1433,7 +1432,7 @@ describe('Logging', () => {
           it('should throw error', () => {
             logging
               .setAclForTopic_(CONFIG)
-              .then(util.noop, err => assert.deepStrictEqual(err, error));
+              .then(noop, err => assert.deepStrictEqual(err, error));
           });
         });
 

--- a/test/log.ts
+++ b/test/log.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import {util} from '@google-cloud/common';
 import * as callbackify from '@google-cloud/promisify';
 import * as assert from 'assert';
 import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
+
+const noop = () => {};
 
 let callbackified = false;
 const fakeCallbackify = extend({}, callbackify, {
@@ -85,10 +86,10 @@ describe('Log', () => {
 
     LOGGING = {
       projectId: '{{project-id}}',
-      entry: util.noop,
-      request: util.noop,
-      loggingService: util.noop,
-      auth: util.noop,
+      entry: noop,
+      request: noop,
+      loggingService: noop,
+      auth: noop,
     };
 
     const options: LogOptions = {};
@@ -534,7 +535,7 @@ describe('Log', () => {
     const LABELS = [];
 
     beforeEach(() => {
-      log.write = util.noop;
+      log.write = noop;
     });
 
     describe('alert', () => {

--- a/test/sink.ts
+++ b/test/sink.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {util} from '@google-cloud/common';
 import * as callbackify from '@google-cloud/promisify';
 import * as assert from 'assert';
 import * as extend from 'extend';
@@ -37,10 +36,10 @@ describe('Sink', () => {
   const PROJECT_ID = 'project-id';
 
   const LOGGING = {
-    createSink: util.noop,
+    createSink: () => {},
     projectId: '{{projectId}}',
-    auth: util.noop,
-    configService: util.noop,
+    auth: () => {},
+    configService: () => {},
   };
   const SINK_NAME = 'sink-name';
 
@@ -210,7 +209,7 @@ describe('Sink', () => {
 
       sink
         .setMetadata(METADATA)
-        .then(util.noop, err => assert.strictEqual(err, error));
+        .then(() => {}, err => assert.strictEqual(err, error));
     });
 
     it('should execute gax method', async () => {


### PR DESCRIPTION
This just removes a few easy wins.  The only method used by `@google-cloud/common` now is `util.isCustomType`, which will need more specific work to exfiltrate. 