### PR TITLE
fix!: populate k8s_container rather than container

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -812,8 +812,6 @@ class Log implements LogSeverityFunctions {
   ): Promise<ApiResponse> {
     const options = opts ? (opts as WriteOptions) : {};
     const self = this;
-
-    console.info('ABOUT TO DETECT RESOURCE')
     if (options.resource) {
       if (options.resource.labels) {
         options.resource.labels = snakeCaseKeys(options.resource.labels);
@@ -824,7 +822,6 @@ class Log implements LogSeverityFunctions {
     } else {
       const resource = await getDefaultResource(this.logging.auth);
       this.logging.detectedResource = resource;
-      console.info(JSON.stringify(resource, null, 2));
       return writeWithResource(resource);
     }
     async function writeWithResource(resource: {} | null) {

--- a/src/log.ts
+++ b/src/log.ts
@@ -813,6 +813,7 @@ class Log implements LogSeverityFunctions {
     const options = opts ? (opts as WriteOptions) : {};
     const self = this;
 
+    console.info('ABOUT TO DETECT RESOURCE')
     if (options.resource) {
       if (options.resource.labels) {
         options.resource.labels = snakeCaseKeys(options.resource.labels);
@@ -823,6 +824,7 @@ class Log implements LogSeverityFunctions {
     } else {
       const resource = await getDefaultResource(this.logging.auth);
       this.logging.detectedResource = resource;
+      console.info(JSON.stringify(resource, null, 2));
       return writeWithResource(resource);
     }
     async function writeWithResource(resource: {} | null) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -119,13 +119,17 @@ export async function getGKEDescriptor() {
     );
   }
 
-  return {
-    type: 'container',
+  const resource = {
+    type: 'k8s_container',
     labels: {
       cluster_name: resp,
-      namespace_id: namespace,
+      namespace_name: namespace,
     },
   };
+  if (process.env.HOSTNAME) {
+    Object.assign(resource.labels, {pod_name: process.env.HOSTNAME});
+  }
+  return resource;
 }
 
 /**

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -119,17 +119,13 @@ export async function getGKEDescriptor() {
     );
   }
 
-  const resource = {
+  return {
     type: 'k8s_container',
     labels: {
       cluster_name: resp,
       namespace_name: namespace,
     },
   };
-  if (process.env.HOSTNAME) {
-    Object.assign(resource.labels, {pod_name: process.env.HOSTNAME});
-  }
-  return resource;
 }
 
 /**

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -198,10 +198,10 @@ describe('metadata', () => {
 
       const descriptor = await metadata.getGKEDescriptor();
       assert.deepStrictEqual(descriptor, {
-        type: 'container',
+        type: 'k8s_container',
         labels: {
           cluster_name: CLUSTER_NAME,
-          namespace_id: FAKE_READFILE_CONTENTS,
+          namespace_name: FAKE_READFILE_CONTENTS,
         },
       });
     });
@@ -383,10 +383,10 @@ describe('metadata', () => {
 
           const defaultResource = await metadata.getDefaultResource(fakeAuth);
           assert.deepStrictEqual(defaultResource, {
-            type: 'container',
+            type: 'k8s_container',
             labels: {
               cluster_name: CLUSTER_NAME,
-              namespace_id: FAKE_READFILE_CONTENTS,
+              namespace_name: FAKE_READFILE_CONTENTS,
             },
           });
         });


### PR DESCRIPTION
BREAKING CHANGE: if using GKE, "Kubernetes Container" type is now properly populated, and logs will be grouped accordingly.

For the gke environment we should populate `k8s_container`, rather than `container`. ~This PR also begins populating `pod_name`, which seems to correlate to `HOST_NAME` in the testing I was doing.~ (reverted this, as it broke tests).

This is a partial fix for #525; there is currently not a good way to get container name, so I've also opened #673.

fixes #525