### PR TITLE
fix(types): extend constructor options from gax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import {Bucket} from '@google-cloud/storage'; // types only
 import {Dataset, BigQuery} from '@google-cloud/bigquery'; // types only
 import {Topic} from '@google-cloud/pubsub'; // types only
 
-export interface LoggingOptions extends gax.GoogleAuthOptions {
+export interface LoggingOptions extends gax.GrpcClientOptions {
   autoRetry?: boolean;
   maxRetries?: number;
   apiEndpoint?: string;


### PR DESCRIPTION
This looks more correct to me, but please review!

`gax.GoogleAuthOptions` is a re-export of `require('google-auth-library').GoogleAuthOptions`.

`gax.GrpcClientOptions` extends `GoogleAuthOptions` with these properties: `auth`, `promise`, and `grpc`.