### PR TITLE
chore: reenable obsolete file tracking

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -21,6 +21,7 @@ import subprocess
 import os
 
 logging.basicConfig(level=logging.DEBUG)
+s.metadata.set_track_obsolete_files(True)
 
 gapic = gcp.GAPICGenerator()
 # tasks has two product names, and a poorly named artman yaml


### PR DESCRIPTION
It now ignores files ignored by github.  Here's the synthtool.metadata it generated:
https://gist.github.com/SurferJeffAtGoogle/5b01fac550bc25294fa4ce8b2ab846d7