### PR TITLE
test: when cleaning, only delete logs that exist

### DIFF
--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -294,7 +294,10 @@ describe('Logging', () => {
               break;
             }
             retries++;
-            console.warn(`delete of ${log.name} failed retries = ${retries}`, _err.message);
+            console.warn(
+              `delete of ${log.name} failed retries = ${retries}`,
+              _err.message
+            );
             await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS));
             continue;
           }

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -290,8 +290,11 @@ describe('Logging', () => {
           try {
             await log.delete();
           } catch (_err) {
+            if (_err.code === 5) {
+              break;
+            }
             retries++;
-            console.warn(`delete of ${log.name} failed retries = ${retries}`);
+            console.warn(`delete of ${log.name} failed retries = ${retries}`, _err.message);
             await new Promise(r => setTimeout(r, WRITE_CONSISTENCY_DELAY_MS));
             continue;
           }


### PR DESCRIPTION
Fixes #550 (maybe?)

When logs are attempted to be deleted in the after hook, it isn't thoroughly handling errors:

  - Test block (an `it`) gets a reference to a Log (no remote operation, just a Log object)
  - Log object is stored in local array (to the `describe`)
  - Test block tries to create a log entry, but fails
  - After hook iterates over local array of Log objects, but **doesn't know if they were actually created**

This PR just makes sure we're only trying to delete logs that exist.