### PR TITLE
feat: add getLogs() and getLogsStream()

### DIFF
--- a/samples/logs.js
+++ b/samples/logs.js
@@ -96,14 +96,14 @@ async function listLogs() {
   // Creates a client
   const logging = new Logging();
 
-  async function listLogs() {
+  async function printLogNames() {
     const [logs] = await logging.getLogs();
     console.log('Logs:');
     logs.forEach(log => {
       console.log(log.name);
     });
   }
-  listLogs();
+  printLogNames();
   // [END logging_list_logs]
 }
 

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -88,6 +88,23 @@ async function writeLogEntryAdvanced(logName, options) {
   // [END logging_write_log_entry_advanced]
 }
 
+async function listLogs() {
+  // [START logging_list_logs]
+  // Imports the Google Cloud client library
+  const {Logging} = require('@google-cloud/logging');
+
+  // Creates a client
+  const logging = new Logging();
+
+  const [logs] = await logging.getLogs();
+  console.log('Logs:');
+  logs.forEach(log => {
+    console.log(log.name);
+  });
+
+  // [END logging_list_logs]
+}
+
 async function listLogEntries(logName) {
   // [START logging_list_log_entries]
   // Imports the Google Cloud client library
@@ -208,6 +225,7 @@ async function main() {
         listLogEntriesAdvanced(opts.filter, opts.limit, opts.sort);
       }
     )
+    .command('list-logs', 'Lists logs in your project.', {}, listLogs)
     .command('list-simple <logName>', 'Lists log entries.', {}, opts =>
       listLogEntries(opts.logName)
     )

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -96,12 +96,14 @@ async function listLogs() {
   // Creates a client
   const logging = new Logging();
 
-  const [logs] = await logging.getLogs();
-  console.log('Logs:');
-  logs.forEach(log => {
-    console.log(log.name);
-  });
-
+  async function listLogs() {
+    const [logs] = await logging.getLogs();
+    console.log('Logs:');
+    logs.forEach(log => {
+      console.log(log.name);
+    });
+  }
+  listLogs();
   // [END logging_list_logs]
 }
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -34,7 +34,7 @@ nock(HOST_ADDRESS)
 
 describe('Logging', () => {
   let PROJECT_ID: string;
-  const TESTS_PREFIX = 'ndoejs-logging-system-test';
+  const TESTS_PREFIX = 'nodejs-logging-system-test';
   const WRITE_CONSISTENCY_DELAY_MS = 5000;
 
   const bigQuery = new BigQuery();


### PR DESCRIPTION
RE: #550

This adds a new method, `logging.getLogs()` and `logging.getLogsStream()` using the logs.list API: https://cloud.google.com/logging/docs/reference/v2/rest/v2/logs/list