### PR TITLE
test: make less requests to avoid quota limit

### DIFF
--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -100,7 +100,7 @@ describe('Logging', () => {
 
     async function deleteLogs() {
       const [logs] = await logging.getLogs({
-        pageSize: 1000,
+        pageSize: 10000,
       });
       const logsToDelete = logs.filter(log => {
         return (

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -110,7 +110,13 @@ describe('Logging', () => {
       });
 
       for (const log of logsToDelete) {
-        await log.delete();
+        try {
+          await log.delete();
+        } catch (e) {
+          if (e.code !== 5) {
+            console.warn(`Deleting ${log.name} failed:`, e.message);
+          }
+        }
       }
     }
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -99,7 +99,9 @@ describe('Logging', () => {
     }
 
     async function deleteLogs() {
-      const [logs] = await logging.getLogs();
+      const [logs] = await logging.getLogs({
+        pageSize: 1000,
+      });
       const logsToDelete = logs.filter(log => {
         return (
           log.name.includes(TESTS_PREFIX) &&


### PR DESCRIPTION
System tests seem to be having an issue with hitting a quota in the after hook:

```
Error: 8 RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Control requests' and limit 'Control requests per minute' of service 'logging.googleapis.com' for consumer 'project_number:1046198160504'.
```

Likely because we just added the `getLogs()` behavior, which will iteratively make requests until there's no `nextPageToken` provided in the response. They seem to come 100 at a time, so I thought, let's bump it up to 1000 and see if that's quotacceptable.