### PR TITLE
test: ignore getLogs() error in cleanup

### DIFF
--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -140,6 +140,10 @@ describe('Logging', () => {
           }
           await new Promise(res => setTimeout(res, timeoutMs));
         } catch (e) {
+          if (e.code === 8) {
+            // Rate limit reached. We'll try to finish cleaning up next time.
+            break;
+          }
           if (e.code !== 5) {
             // Log exists, but couldn't be deleted.
             console.warn(`Deleting ${log.name} failed:`, e.message);

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -100,9 +100,20 @@ describe('Logging', () => {
 
     async function deleteLogs() {
       const maxPatienceMs = 300000; // 5 minutes.
-      const [logs] = await logging.getLogs({
-        pageSize: 10000,
-      });
+      let logs;
+
+      try {
+        [logs] = await logging.getLogs({
+          pageSize: 10000,
+        });
+      } catch (e) {
+        // We'll ignore rate-limiting errors. The next test run can try again.
+        if (e.code !== 8) {
+          console.warn(e.message);
+        }
+        return;
+      }
+
       const logsToDelete = logs.filter(log => {
         return (
           log.name.startsWith(TESTS_PREFIX) &&

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -121,7 +121,7 @@ describe('Logging', () => {
       });
 
       if (logsToDelete.length > 0) {
-        console.log('Deleting', logsToDelete.length, 'test logs');
+        console.log('Deleting', logsToDelete.length, 'test logs...');
       }
 
       let numLogsDeleted = 0;
@@ -141,6 +141,9 @@ describe('Logging', () => {
           await new Promise(res => setTimeout(res, timeoutMs));
         } catch (e) {
           if (e.code === 8) {
+            console.warn(
+              'Rate limit reached. The next test run will attempt to delete the rest'
+            );
             // Rate limit reached. We'll try to finish cleaning up next time.
             break;
           }

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -144,7 +144,6 @@ describe('Logging', () => {
             console.warn(
               'Rate limit reached. The next test run will attempt to delete the rest'
             );
-            // Rate limit reached. We'll try to finish cleaning up next time.
             break;
           }
           if (e.code !== 5) {

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -107,10 +107,9 @@ describe('Logging', () => {
           pageSize: 10000,
         });
       } catch (e) {
-        // We'll ignore rate-limiting errors. The next test run can try again.
-        if (e.code !== 8) {
-          console.warn(e.message);
-        }
+        console.warn('Error retrieving logs:');
+        console.warn(`  ${e.message}`);
+        console.warn('No test logs were deleted');
         return;
       }
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -147,6 +147,10 @@ describe('Logging', () => {
           }
         }
       }
+
+      if (logsToDelete.length > 0) {
+        console.log(`${numLogsDeleted}/${logsToDelete.length} logs deleted`);
+      }
     }
 
     async function getAndDelete(method: Function) {


### PR DESCRIPTION
Fixes #702 

This puts more certainty that failed test log removal results only in `console.warn`s, and not test failure.