### PR TITLE
chore(test): Ensure writeLogEntries is actually called on log write.

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -867,6 +867,7 @@ class Log implements LogSeverityFunctions {
     }
   }
 
+  // TODO proper signature of `private decorateEntries` (sans underscore suffix)
   /**
    * All entries are passed through here in order to get them serialized.
    *
@@ -887,6 +888,7 @@ class Log implements LogSeverityFunctions {
     });
   }
 
+  // TODO consider refactoring `truncateEntries` so that it does not mutate
   /**
    * Truncate log entries at maxEntrySize, so that error is not thrown, see:
    * https://cloud.google.com/logging/quotas

--- a/test/log.ts
+++ b/test/log.ts
@@ -12,39 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as callbackify from '@google-cloud/promisify';
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
-import {Log as LOG, WriteOptions, GetEntriesRequest} from '../src/log';
-import {Logging} from '../src/index';
-
-const noop = () => {};
-
-let callbackified = false;
-const fakeCallbackify = extend({}, callbackify, {
-  callbackifyAll(c: Function, options: callbackify.CallbackifyAllOptions) {
-    if (c.name !== 'Log') {
-      return;
-    }
-    callbackified = true;
-    assert.deepStrictEqual(options.exclude, ['entry', 'getEntriesStream']);
-  },
-});
-
-import {Entry} from '../src';
+import {Entry, Logging} from '../src';
+import {Log as LOG, LogOptions, WriteOptions} from '../src/log';
 import {Data, EntryJson, LogEntry} from '../src/entry';
-import {LogOptions} from '../src/log';
-
-const originalGetDefaultResource = async () => {
-  return 'very-fake-resource';
-};
-
-const fakeMetadata = {
-  getDefaultResource: originalGetDefaultResource,
-};
 
 describe('Log', () => {
   // tslint:disable-next-line variable-name
@@ -53,6 +28,7 @@ describe('Log', () => {
   let log: any;
 
   const PROJECT_ID = 'project-id';
+  const FAKE_RESOURCE = 'fake-resource';
   const LOG_NAME = 'escaping/required/for/this/log-name';
   const LOG_NAME_ENCODED = encodeURIComponent(LOG_NAME);
   const LOG_NAME_FORMATTED = [
@@ -64,35 +40,54 @@ describe('Log', () => {
 
   let LOGGING: Logging;
 
-  let assignSeverityToEntriesOverride: Function | null = null;
+  const callbackifyFake = {
+    callbackifyAll: sinon.stub(),
+  };
+
+  const metadataFake = {
+    getDefaultResource: sinon.stub(),
+  };
 
   before(() => {
     Log = proxyquire('../src/log', {
-      '@google-cloud/promisify': fakeCallbackify,
+      '@google-cloud/promisify': callbackifyFake,
       './entry': {Entry},
-      './metadata': fakeMetadata,
+      './metadata': metadataFake,
     }).Log;
-    const assignSeverityToEntries_ = Log.assignSeverityToEntries_;
-    Log.assignSeverityToEntries_ = (...args) =>
-      (assignSeverityToEntriesOverride || assignSeverityToEntries_).apply(
-        null,
-        args
-      );
-  });
 
-  beforeEach(() => {
     log = createLogger();
   });
 
-  function createLogger(maxEntrySize?: number) {
-    assignSeverityToEntriesOverride = null;
+  beforeEach(() => {
+    metadataFake.getDefaultResource.reset();
+    log.logging.entry.reset();
+    log.logging.getEntries.reset();
+    log.logging.getEntriesStream.reset();
+    log.logging.request.reset();
+    log.logging.loggingService.deleteLog.reset();
+    log.logging.loggingService.writeLogEntries.reset();
+    log.logging.auth.getEnv.reset();
+    log.logging.auth.getProjectId.reset();
 
+    metadataFake.getDefaultResource.returns(FAKE_RESOURCE);
+    log.logging.auth.getProjectId.resolves(PROJECT_ID);
+  });
+
+  function createLogger(maxEntrySize?: number) {
     LOGGING = ({
       projectId: '{{project-id}}',
-      entry: noop,
-      request: noop,
-      loggingService: noop,
-      auth: noop,
+      entry: sinon.stub(),
+      getEntries: sinon.stub(),
+      getEntriesStream: sinon.stub(),
+      request: sinon.stub(),
+      loggingService: {
+        deleteLog: sinon.stub(),
+        writeLogEntries: sinon.stub(),
+      },
+      auth: {
+        getEnv: sinon.stub(),
+        getProjectId: sinon.stub(),
+      },
     } as {}) as Logging;
 
     const options: LogOptions = {};
@@ -105,7 +100,12 @@ describe('Log', () => {
 
   describe('instantiation', () => {
     it('should callbackify all the things', () => {
-      assert(callbackified);
+      assert(
+        callbackifyFake.callbackifyAll.calledWithExactly(
+          Log,
+          sinon.match({exclude: ['entry', 'getEntriesStream']})
+        )
+      );
     });
 
     it('should localize the escaped name', () => {
@@ -210,36 +210,23 @@ describe('Log', () => {
   });
 
   describe('delete', () => {
-    beforeEach(() => {
-      log.logging.auth.getProjectId = async () => PROJECT_ID;
-    });
-
     it('should execute gax method', async () => {
-      log.logging.loggingService.deleteLog = async (
-        reqOpts: {},
-        gaxOpts: {}
-      ) => {
-        assert.deepStrictEqual(reqOpts, {
-          logName: log.formattedName_,
-        });
-
-        assert.strictEqual(gaxOpts, undefined);
-      };
-
       await log.delete();
+      assert(
+        log.logging.loggingService.deleteLog.calledWithExactly(
+          {
+            logName: log.formattedName_,
+          },
+          undefined
+        )
+      );
     });
 
     it('should accept gaxOptions', async () => {
-      const gaxOptions = {};
-
-      log.logging.loggingService.deleteLog = async (
-        reqOpts: {},
-        gaxOpts: {}
-      ) => {
-        assert.strictEqual(gaxOpts, gaxOptions);
-      };
-
-      await log.delete(gaxOptions);
+      await log.delete({});
+      assert(
+        log.logging.loggingService.deleteLog.calledWith(sinon.match.any, {})
+      );
     });
   });
 
@@ -249,43 +236,29 @@ describe('Log', () => {
         val: true,
       } as LogEntry;
       const data = {};
-
       const entryObject = {};
-
-      log.logging.entry = (metadata_: {}, data_: {}) => {
-        assert.deepStrictEqual(metadata_, metadata);
-        assert.strictEqual(data_, data);
-        return entryObject;
-      };
+      log.logging.entry.returns(entryObject);
 
       const entry = log.entry(metadata, data);
       assert.strictEqual(entry, entryObject);
+      assert(log.logging.entry.calledWithExactly(metadata, data));
     });
 
-    it('should assume one argument means data', done => {
+    it('should assume one argument means data', () => {
       const data = {};
-      log.logging.entry = (metadata: {}, data_: {}) => {
-        assert.strictEqual(data_, data);
-        done();
-      };
       log.entry(data);
+      assert(log.logging.entry.calledWith(sinon.match.any, data));
     });
   });
 
   describe('getEntries', () => {
-    beforeEach(() => {
-      log.logging.auth.getProjectId = async () => PROJECT_ID;
-    });
-
-    const EXPECTED_OPTIONS = {
-      filter: 'logName="' + LOG_NAME_FORMATTED + '"',
-    };
-
     it('should call Logging getEntries with defaults', async () => {
-      log.logging.getEntries = (options: GetEntriesRequest) => {
-        assert.deepStrictEqual(options, EXPECTED_OPTIONS);
-      };
       await log.getEntries();
+      assert(
+        log.logging.getEntries.calledWithExactly({
+          filter: `logName="${LOG_NAME_FORMATTED}"`,
+        })
+      );
     });
 
     it('should add logName filter to user provided filter', async () => {
@@ -293,52 +266,50 @@ describe('Log', () => {
         custom: true,
         filter: 'custom filter',
       };
-      log.logging.projectId = await log.logging.auth.getProjectId();
-      log.formattedName_ = Log.formatName_(log.logging.projectId, log.name);
-
       const expectedOptions = extend({}, options);
-      expectedOptions.filter = `(${options.filter}) AND logName="${log.formattedName_}"`;
-
-      log.logging.getEntries = (options_: {}) => {
-        assert.notDeepStrictEqual(options_, options);
-        assert.deepStrictEqual(options_, expectedOptions);
-      };
+      expectedOptions.filter = `(${options.filter}) AND logName="${LOG_NAME_FORMATTED}"`;
 
       await log.getEntries(options);
+      assert(log.logging.getEntries.calledWithExactly(expectedOptions));
     });
   });
 
   describe('getEntriesStream', () => {
-    const fakeStream = {};
-    const EXPECTED_OPTIONS = {
-      log: LOG_NAME_ENCODED,
-    };
+    const FAKE_STREAM = {};
 
-    it('should call Logging getEntriesStream with defaults', done => {
-      log.logging.getEntriesStream = (options: {}) => {
-        assert.deepStrictEqual(options, EXPECTED_OPTIONS);
-        setImmediate(done);
-        return fakeStream;
-      };
-
-      const stream = log.getEntriesStream();
-      assert.strictEqual(stream, fakeStream);
+    beforeEach(() => {
+      log.logging.getEntriesStream.returns(FAKE_STREAM);
     });
 
-    it('should allow overriding the options', done => {
+    it('should call Logging getEntriesStream with defaults', () => {
+      const stream = log.getEntriesStream();
+      assert.strictEqual(stream, FAKE_STREAM);
+      assert(
+        log.logging.getEntriesStream.calledWithExactly({
+          log: LOG_NAME_ENCODED,
+        })
+      );
+    });
+
+    it('should allow overriding the options', () => {
       const options = {
         custom: true,
         filter: 'custom filter',
       };
 
-      log.logging.getEntriesStream = (options_: {}) => {
-        assert.deepStrictEqual(options_, extend({}, EXPECTED_OPTIONS, options));
-        setImmediate(done);
-        return fakeStream;
-      };
-
       const stream = log.getEntriesStream(options);
-      assert.strictEqual(stream, fakeStream);
+      assert.strictEqual(stream, FAKE_STREAM);
+      assert(
+        log.logging.getEntriesStream.calledWithExactly(
+          extend(
+            {},
+            {
+              log: LOG_NAME_ENCODED,
+            },
+            options
+          )
+        )
+      );
     });
   });
 
@@ -346,13 +317,13 @@ describe('Log', () => {
     let ENTRY: Entry;
     let ENTRIES: Entry[];
     let OPTIONS: WriteOptions;
-    const FAKE_RESOURCE = 'fake-resource';
     let truncateEntriesStub: sinon.SinonStub;
     let decorateEntriesStub: sinon.SinonStub;
-    let fakeResourceStub: sinon.SinonStub;
-    let projectIdStub: sinon.SinonStub;
-    let writeLogStub: sinon.SinonStub;
     let origDetectedResource: string;
+
+    before(() => {
+      origDetectedResource = log.logging.detectedResource;
+    });
 
     beforeEach(() => {
       ENTRY = {} as Entry;
@@ -360,30 +331,10 @@ describe('Log', () => {
       OPTIONS = {} as WriteOptions;
       decorateEntriesStub = sinon.stub(log, 'decorateEntries_').returnsArg(0);
       truncateEntriesStub = sinon.stub(log, 'truncateEntries').returnsArg(0);
-      fakeResourceStub = sinon
-        .stub(fakeMetadata, 'getDefaultResource')
-        .resolves(FAKE_RESOURCE);
-      projectIdStub = sinon.stub().resolves(PROJECT_ID);
-      writeLogStub = sinon.stub();
-
-      // loggingService and auth are fixtures defined in the root suite
-      // they don't have these methods, but we need them for this sub suite
-      log.logging.auth.getProjectId = projectIdStub;
-      log.logging.loggingService.writeLogEntries = writeLogStub;
-
-      // primitives used in the coming tests must be cached and swapped
-      // to avoid carrying state to latter tests
-      origDetectedResource = log.logging.detectedResource;
     });
-
     afterEach(() => {
       decorateEntriesStub.restore();
       truncateEntriesStub.restore();
-      fakeResourceStub.restore();
-
-      delete log.logging.auth.getProjectId;
-      delete log.logging.loggingService.writeLogEntries;
-
       log.logging.detectedResource = origDetectedResource;
     });
 
@@ -395,7 +346,7 @@ describe('Log', () => {
 
       await log.write(ENTRIES, optionsWithResource);
       assert(
-        writeLogStub.calledOnceWithExactly(
+        log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
           {
             logName: log.formattedName_,
             entries: ENTRIES,
@@ -408,21 +359,23 @@ describe('Log', () => {
 
     it('should cache a detected resource', async () => {
       const fakeResource = 'test-level-fake-resource';
-      fakeResourceStub.resolves(fakeResource);
+      metadataFake.getDefaultResource.resetBehavior();
+      metadataFake.getDefaultResource.resolves(fakeResource);
 
       await log.write(ENTRIES);
-      assert(writeLogStub.calledOnce);
+      assert(log.logging.loggingService.writeLogEntries.calledOnce);
       assert.strictEqual(log.logging.detectedResource, fakeResource);
     });
 
     it('should re-use detected resource', async () => {
       const reusableDetectedResource = 'environment-default-resource';
       log.logging.detectedResource = reusableDetectedResource;
-      fakeResourceStub.throws('Cached resource was not used.');
+      metadataFake.getDefaultResource.resetBehavior();
+      metadataFake.getDefaultResource.throws('Cached resource was not used.');
 
       await log.write(ENTRIES);
       assert(
-        writeLogStub.calledOnceWith(
+        log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             resource: reusableDetectedResource,
           })
@@ -447,7 +400,7 @@ describe('Log', () => {
 
       await log.write(ENTRIES, optionsWithResource);
       assert(
-        writeLogStub.calledOnceWithExactly(
+        log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
           {
             logName: log.formattedName_,
             entries: ENTRIES,
@@ -461,7 +414,7 @@ describe('Log', () => {
     it('should call gax method', async () => {
       await log.write(ENTRIES, OPTIONS);
       assert(
-        writeLogStub.calledOnceWithExactly(
+        log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
           {
             logName: log.formattedName_,
             entries: ENTRIES,
@@ -479,7 +432,7 @@ describe('Log', () => {
       await log.write(ENTRIES, OPTIONS);
       assert(decorateEntriesStub.calledOnceWithExactly(ENTRIES));
       assert(
-        writeLogStub.calledOnceWith(
+        log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: 'decorated entries',
           })
@@ -493,7 +446,7 @@ describe('Log', () => {
       await log.write(ENTRY, OPTIONS);
       assert(decorateEntriesStub.calledOnceWithExactly(arrifiedEntries));
       assert(
-        writeLogStub.calledOnceWith(
+        log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: arrifiedEntries,
           })
@@ -506,7 +459,7 @@ describe('Log', () => {
       assert(truncateEntriesStub.calledAfter(decorateEntriesStub));
       assert(truncateEntriesStub.calledOnceWithExactly(ENTRIES));
       assert(
-        writeLogStub.calledOnceWith(
+        log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             entries: ENTRIES,
           })
@@ -516,13 +469,18 @@ describe('Log', () => {
 
     it('should not require options', async () => {
       await log.write(ENTRY);
-      assert(writeLogStub.calledOnceWithExactly(sinon.match.object, undefined));
+      assert(
+        log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
+          sinon.match.object,
+          undefined
+        )
+      );
     });
 
     it('should pass through additional options', async () => {
       await log.write(ENTRY, {dryRun: true, partialSuccess: false});
       assert(
-        writeLogStub.calledOnceWith(
+        log.logging.loggingService.writeLogEntries.calledOnceWith(
           sinon.match({
             dryRun: true,
             partialSuccess: false,
@@ -609,280 +567,106 @@ describe('Log', () => {
   });
 
   describe('severity shortcuts', () => {
-    const ENTRY = {} as Entry;
-    const LABELS = [] as WriteOptions;
+    let ENTRY: Entry;
+    let LABELS: WriteOptions;
+    let assignSeverityStub: sinon.SinonStub;
+    let writeStub: sinon.SinonStub;
 
     beforeEach(() => {
-      log.write = noop;
+      ENTRY = {} as Entry;
+      LABELS = [] as WriteOptions;
+      assignSeverityStub = sinon.stub(Log, 'assignSeverityToEntries_');
+      writeStub = sinon.stub(log, 'write');
     });
 
-    describe('alert', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'ALERT');
-        };
-        await log.alert(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-        assignSeverityToEntriesOverride = () => assignedEntries;
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-        await log.alert(ENTRY, LABELS);
-      });
+    afterEach(() => {
+      assignSeverityStub.restore();
+      writeStub.restore();
     });
 
-    describe('critical', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'CRITICAL');
-        };
+    [
+      'alert',
+      'critical',
+      'debug',
+      'emergency',
+      'error',
+      'info',
+      'notice',
+      'warning',
+    ].forEach(severityMethodName => {
+      describe(severityMethodName, () => {
+        let severityMethod: Function;
 
-        await log.critical(ENTRY, LABELS);
-      });
+        beforeEach(() => {
+          severityMethod = log[severityMethodName].bind(log);
+        });
 
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-        assignSeverityToEntriesOverride = () => assignedEntries;
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-        await log.critical(ENTRY, LABELS);
-      });
-    });
+        it('should format the entries', async () => {
+          const severity = severityMethodName.toUpperCase();
+          await severityMethod(ENTRY, LABELS);
+          assert(assignSeverityStub.calledOnceWith(ENTRY, severity));
+        });
 
-    describe('debug', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'DEBUG');
-        };
-
-        await log.debug(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-        assignSeverityToEntriesOverride = () => assignedEntries;
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-        await log.debug(ENTRY, LABELS);
-      });
-    });
-
-    describe('emergency', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'EMERGENCY');
-        };
-
-        await log.emergency(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-        assignSeverityToEntriesOverride = () => assignedEntries;
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-        await log.emergency(ENTRY, LABELS);
-      });
-    });
-
-    describe('error', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'ERROR');
-        };
-        await log.error(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-
-        assignSeverityToEntriesOverride = () => {
-          return assignedEntries;
-        };
-
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-
-        await log.error(ENTRY, LABELS);
-      });
-    });
-
-    describe('info', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'INFO');
-        };
-
-        await log.info(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-
-        assignSeverityToEntriesOverride = () => {
-          return assignedEntries;
-        };
-
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-
-        await log.info(ENTRY, LABELS);
-      });
-    });
-
-    describe('notice', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'NOTICE');
-        };
-
-        await log.notice(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-
-        assignSeverityToEntriesOverride = () => {
-          return assignedEntries;
-        };
-
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-
-        await log.notice(ENTRY, LABELS);
-      });
-    });
-
-    describe('warning', () => {
-      it('should format the entries', async () => {
-        assignSeverityToEntriesOverride = (
-          entries: Entry[],
-          severity: string
-        ) => {
-          assert.strictEqual(entries, ENTRY);
-          assert.strictEqual(severity, 'WARNING');
-        };
-
-        await log.warning(ENTRY, LABELS);
-      });
-
-      it('should pass correct arguments to write', async () => {
-        const assignedEntries = [] as Entry[];
-        assignSeverityToEntriesOverride = () => assignedEntries;
-        log.write = async (entry: Entry, labels: WriteOptions) => {
-          assert.strictEqual(entry, assignedEntries);
-          assert.strictEqual(labels, LABELS);
-        };
-        await log.warning(ENTRY, LABELS);
+        it('should pass correct arguments to write', async () => {
+          const assignedEntries = [] as Entry[];
+          assignSeverityStub.returns(assignedEntries);
+          await severityMethod(ENTRY, LABELS);
+          assert(writeStub.calledOnceWith(assignedEntries));
+        });
       });
     });
   });
 
   describe('decorateEntries_', () => {
-    const toJSONResponse = {};
-
-    class FakeEntry {
-      toJSON() {
-        return toJSONResponse;
-      }
-    }
+    // tslint:disable-next-line no-any
+    let toJSONResponse: any;
+    let logEntryStub: sinon.SinonStub;
+    let toJSONStub: sinon.SinonStub;
 
     beforeEach(() => {
-      log.entry = () => new FakeEntry() as Entry;
+      toJSONResponse = {};
+      toJSONStub = sinon.stub().returns(toJSONResponse);
+      logEntryStub = sinon.stub(log, 'entry').returns({
+        toJSON: toJSONStub,
+      });
+    });
+
+    afterEach(() => {
+      logEntryStub.restore();
     });
 
     it('should create an Entry object if one is not provided', () => {
       const entry = {};
-
-      log.entry = (entry_: Entry) => {
-        assert.strictEqual(entry_, entry);
-        return new FakeEntry() as Entry;
-      };
-
       const decoratedEntries = log.decorateEntries_([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
+      assert(log.entry.calledWithExactly(entry));
     });
 
     it('should get JSON format from Entry object', () => {
-      log.entry = () => {
-        throw new Error('should not be called');
-      };
       const entry = new Entry();
       entry.toJSON = () => (toJSONResponse as {}) as EntryJson;
       const decoratedEntries = log.decorateEntries_([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
+      assert(log.entry.notCalled);
     });
 
-    it('should pass log.removeCircular to toJSON', done => {
+    it('should pass log.removeCircular to toJSON', () => {
       log.removeCircular_ = true;
-
       const entry = new Entry();
-      entry.toJSON = options_ => {
-        assert.deepStrictEqual(options_, {removeCircular: true});
-        setImmediate(done);
-        return {} as EntryJson;
-      };
+      const localJSONStub = sinon
+        .stub(entry, 'toJSON')
+        .returns({} as EntryJson);
 
       log.decorateEntries_([entry]);
+      assert(localJSONStub.calledWithExactly({removeCircular: true}));
     });
 
     it('should throw error from serialization', () => {
-      const error = new Error('Error.');
-
       const entry = new Entry();
-      entry.toJSON = () => {
-        throw error;
-      };
-
-      try {
+      sinon.stub(entry, 'toJSON').throws('Error.');
+      assert.throws(() => {
         log.decorateEntries_([entry]);
-      } catch (err) {
-        assert.strictEqual(err, error);
-      }
+      }, 'Error.');
     });
   });
 });


### PR DESCRIPTION
The test cases for log.write had their assertions within a manual logging service stub for writeLogEntries. If writeLogEntries was never invoked, these tests would still succeed. The refactor for the write test cases use sinon assertion patterns to avoid this scenario. Unit tests for the write suite should now read better, especially as the intention of each test has been refined too.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

~Fixes #<issue_number_goes_here>~ no open issue for this 🦕
