### PR TITLE
chore(docs): stackdriver logging limits of 256kb/entry and 10mb/write…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "test": "c8 mocha --recursive ./build/test",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs": "npm run compile",
     "presystem-test": "npm run compile",
     "system-test": "c8 mocha build/system-test --timeout 600000",
     "samples-test": "cd samples/ && c8 npm test && cd ../",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -50,6 +50,11 @@ export interface ToJsonOptions {
 /**
  * Create an entry object to define new data to insert into a log.
  *
+ * Note, [Cloud Logging Quotas and limits]{@link https://cloud.google.com/logging/quotas}
+ * dictates that the maximum log entry size, including all
+ * [LogEntry Resource properties]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry},
+ * cannot exceed _approximately_ 256 KB.
+ *
  * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
  *
  * @class

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,9 +426,14 @@ class Logging {
   /**
    * Create an entry object.
    *
-   * Note that using this method will not itself make any API requests. You will
-   * use the object returned in other API calls, such as
+   * Using this method will not itself make any API requests. You will use
+   * the object returned in other API calls, such as
    * {@link Log#write}.
+   *
+   * Note, [Cloud Logging Quotas and limits]{@link https://cloud.google.com/logging/quotas}
+   * dictates that the maximum log entry size, including all
+   * [LogEntry Resource properties]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry},
+   * cannot exceed _approximately_ 256 KB.
    *
    * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
    *

--- a/src/log.ts
+++ b/src/log.ts
@@ -366,9 +366,14 @@ class Log implements LogSeverityFunctions {
   /**
    * Create an entry object for this log.
    *
-   * Note that using this method will not itself make any API requests. You will
-   * use the object returned in other API calls, such as
+   * Using this method will not itself make any API requests. You will use
+   * the object returned in other API calls, such as
    * {@link Log#write}.
+   *
+   * Note, [Cloud Logging Quotas and limits]{@link https://cloud.google.com/logging/quotas}
+   * dictates that the maximum log entry size, including all
+   * [LogEntry Resource properties]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry},
+   * cannot exceed _approximately_ 256 KB.
    *
    * @see [LogEntry JSON representation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry}
    *
@@ -736,6 +741,11 @@ class Log implements LogSeverityFunctions {
    */
   /**
    * Write log entries to Stackdriver Logging.
+   *
+   * Note, [Cloud Logging Quotas and limits]{@link https://cloud.google.com/logging/quotas}
+   * dictates that the maximum cumulative size of all entries per write,
+   * including all [LogEntry Resource properties]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry},
+   * cannot exceed _approximately_ 10 MB.
    *
    * @see [entries.write API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write}
    *


### PR DESCRIPTION
chore(docs): stackdriver logging limits of 256kb/entry and 10mb/write, force compilation before doc script (#531)

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #531 🦕
