### PR TITLE
test: remove fake failing tests used to test build-cop

### DIFF
--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -39,13 +39,4 @@ describe('quickstart', () => {
     const stdout = execSync(`${cmd} ${projectId} ${logName}`);
     assert.include(stdout, 'Logged: Hello, world!');
   });
-
-  it('fails in continuous (sample)', () => {
-    if (
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR &&
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR.includes('continuous')
-    ) {
-      assert.strictEqual(true, false);
-    }
-  });
 });

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -668,13 +668,4 @@ describe('Logging', async () => {
     const timeCreated = name.substr(TESTS_PREFIX.length + 1).split(/-|_/g)[0];
     return new Date(Number(timeCreated));
   }
-
-  it('fails in continuous (system)', () => {
-    if (
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR &&
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR.includes('continuous')
-    ) {
-      assert.strictEqual(true, false);
-    }
-  });
 });

--- a/test/log.ts
+++ b/test/log.ts
@@ -848,13 +848,4 @@ describe('Log', () => {
       }
     });
   });
-
-  it('fails in continuous (unit)', () => {
-    if (
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR &&
-      process.env.KOKORO_BUILD_ARTIFACTS_SUBDIR.includes('continuous')
-    ) {
-      assert.strictEqual(true, false);
-    }
-  });
 });


### PR DESCRIPTION
removes the fake failing tests added to test build cop configuration.
