### PR TITLE
build: synth.metadata had bad entry

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -4,22 +4,15 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/nodejs-logging.git",
-        "sha": "198485ced9e3bf26440eb182f3eba1b82a10b560"
+        "sha": "d1df1bdc1d536d3626dc1b85d357cf6ec18f80e8"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1bd77e8ce6f953ac641af7966d0c52646afc16a8",
-        "internalRef": "305974465"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "6f32150677c9784f3c3a7e1949472bd29c9d72c5"
+        "sha": "3824f547aa44df459580615c73cabb30a2a78ee0",
+        "internalRef": "306254195"
       }
     }
   ],


### PR DESCRIPTION
`synth.metadata` somehow got a bad entry in it (I confirmed locally that the `sha` in the metadata throws an exception).

Fixes: #791 