### PR TITLE
test: fix flaky sample tests

### DIFF
--- a/samples/test/http-request.test.js
+++ b/samples/test/http-request.test.js
@@ -22,7 +22,7 @@ const cp = require('child_process');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const TESTS_PREFIX = 'nodejs-docs-samples-test';
-const logName = generateName();
+const logName = `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
 const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node http-request';
 
@@ -32,7 +32,3 @@ describe('http-request', () => {
     assert.include(stdout, 'Logged: Hello, world!');
   });
 });
-
-function generateName() {
-  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
-}

--- a/samples/test/http-request.test.js
+++ b/samples/test/http-request.test.js
@@ -15,25 +15,24 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it, after} = require('mocha');
+const {describe, it} = require('mocha');
 const uuid = require('uuid');
-const {Logging} = require('@google-cloud/logging');
 const cp = require('child_process');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const logging = new Logging();
-const logName = `nodejs-docs-samples-test-${uuid.v4()}`;
+const TESTS_PREFIX = 'nodejs-docs-samples-test';
+const logName = generateName();
 const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node http-request';
 
 describe('http-request', () => {
-  after(async () => {
-    await logging.log(logName).delete().catch(console.warn);
-  });
-
   it('should log an entry', () => {
     const stdout = execSync(`${cmd} ${projectId} ${logName}`);
     assert.include(stdout, 'Logged: Hello, world!');
   });
 });
+
+function generateName() {
+  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
+}

--- a/samples/test/logs.test.js
+++ b/samples/test/logs.test.js
@@ -15,16 +15,87 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it} = require('mocha');
+const {describe, it, after} = require('mocha');
 const cp = require('child_process');
 const uuid = require('uuid');
+const {Logging} = require('@google-cloud/logging');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cmd = 'node logs';
-const logName = `nodejs-logging-logs-test-${uuid.v4()}`;
+const TESTS_PREFIX = 'nodejs-docs-samples-test';
+const logName = generateName();
+const projectId = process.env.GCLOUD_PROJECT;
+const logging = new Logging({projectId});
 const message = 'Hello world!';
 
 describe('logs', () => {
+  after(async () => {
+    const oneHourAgo = new Date();
+    oneHourAgo.setHours(oneHourAgo.getHours() - 1);
+    await deleteLogs();
+
+    async function deleteLogs() {
+      const maxPatienceMs = 300000; // 5 minutes.
+      let logs;
+
+      try {
+        [logs] = await logging.getLogs({
+          pageSize: 10000,
+        });
+      } catch (e) {
+        console.warn('Error retrieving logs:');
+        console.warn(`  ${e.message}`);
+        console.warn('No test logs were deleted');
+        return;
+      }
+
+      const logsToDelete = logs.filter(log => {
+        return (
+          log.name.startsWith(TESTS_PREFIX) &&
+          getDateFromGeneratedName(log.name) < oneHourAgo
+        );
+      });
+
+      if (logsToDelete.length > 0) {
+        console.log('Deleting', logsToDelete.length, 'test logs...');
+      }
+
+      let numLogsDeleted = 0;
+      for (const log of logsToDelete) {
+        console.log(log.name);
+        try {
+          await log.delete();
+          numLogsDeleted++;
+
+          // A one second gap is preferred between delete calls to avoid rate
+          // limiting.
+          let timeoutMs = 1000;
+          if (numLogsDeleted * 1000 > maxPatienceMs) {
+            // This is taking too long. If we hit the rate limit, we'll
+            // hopefully scoop up the stragglers on a future test run.
+            timeoutMs = 10;
+          }
+          await new Promise(res => setTimeout(res, timeoutMs));
+        } catch (e) {
+          if (e.code === 8) {
+            console.warn(
+              'Rate limit reached. The next test run will attempt to delete the rest'
+            );
+            break;
+          }
+          if (e.code !== 5) {
+            // Log exists, but couldn't be deleted.
+            console.warn(`Deleting ${log.name} failed:`, e.message);
+          }
+        }
+      }
+
+      if (logsToDelete.length > 0) {
+        console.log(`${numLogsDeleted}/${logsToDelete.length} logs deleted`);
+      }
+    }
+  });
+
   it('should write a log entry', () => {
     const output = execSync(
       `${cmd} write ${logName} '{"type":"global"}' '{"message":"${message}"}'`
@@ -37,3 +108,14 @@ describe('logs', () => {
     assert.include(output, `Wrote to ${logName}`);
   });
 });
+
+function generateName() {
+  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
+}
+
+// Parse the time the resource was created using the resource id
+// Format 1: ${TESTS_PREFIX}-${date}-${uuid}
+function getDateFromGeneratedName(name) {
+  const timeCreated = name.substr(TESTS_PREFIX.length + 1).split(/-/g)[0];
+  return new Date(Number(timeCreated));
+}

--- a/samples/test/logs.test.js
+++ b/samples/test/logs.test.js
@@ -23,7 +23,7 @@ const {Logging} = require('@google-cloud/logging');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cmd = 'node logs';
 const TESTS_PREFIX = 'nodejs-docs-samples-test';
-const logName = generateName();
+const logName = `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
 const projectId = process.env.GCLOUD_PROJECT;
 const logging = new Logging({projectId});
 const message = 'Hello world!';
@@ -108,10 +108,6 @@ describe('logs', () => {
     assert.include(output, `Wrote to ${logName}`);
   });
 });
-
-function generateName() {
-  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
-}
 
 // Parse the time the resource was created using the resource id
 // Format 1: ${TESTS_PREFIX}-${date}-${uuid}

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -15,25 +15,24 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it, after} = require('mocha');
+const {describe, it} = require('mocha');
 const uuid = require('uuid');
-const {Logging} = require('@google-cloud/logging');
 const cp = require('child_process');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
-const logging = new Logging();
-const logName = `nodejs-docs-samples-test-${uuid.v4()}`;
+const TESTS_PREFIX = 'nodejs-docs-samples-test';
+const logName = generateName();
 const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node quickstart';
 
 describe('quickstart', () => {
-  after(async () => {
-    await logging.log(logName).delete().catch(console.warn);
-  });
-
   it('should log an entry', () => {
     const stdout = execSync(`${cmd} ${projectId} ${logName}`);
     assert.include(stdout, 'Logged: Hello, world!');
   });
 });
+
+function generateName() {
+  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
+}

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -22,7 +22,7 @@ const cp = require('child_process');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const TESTS_PREFIX = 'nodejs-docs-samples-test';
-const logName = generateName();
+const logName = `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
 const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node quickstart';
 
@@ -32,7 +32,3 @@ describe('quickstart', () => {
     assert.include(stdout, 'Logged: Hello, world!');
   });
 });
-
-function generateName() {
-  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
-}

--- a/samples/test/sinks.test.js
+++ b/samples/test/sinks.test.js
@@ -37,7 +37,6 @@ describe('sinks', () => {
   });
 
   after(async () => {
-    await logging.sink(sinkName).delete().catch(console.warn);
     await storage.bucket(bucketName).delete().catch(console.warn);
   });
 

--- a/samples/test/sinks.test.js
+++ b/samples/test/sinks.test.js
@@ -26,7 +26,8 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cmd = 'node sinks.js';
 const bucketName = `nodejs-logging-sinks-test-${uuid.v4()}`;
-const sinkName = `nodejs-logging-sinks-test-${uuid.v4()}`;
+const TESTS_PREFIX = 'nodejs-docs-samples-test';
+const sinkName = generateName();
 const filter = 'severity > WARNING';
 const logging = new Logging();
 const storage = new Storage();
@@ -79,3 +80,7 @@ describe('sinks', () => {
     await assert.rejects(logging.sink(sinkName).getMetadata());
   });
 });
+
+function generateName() {
+  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
+}

--- a/samples/test/sinks.test.js
+++ b/samples/test/sinks.test.js
@@ -26,8 +26,7 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cmd = 'node sinks.js';
 const bucketName = `nodejs-logging-sinks-test-${uuid.v4()}`;
-const TESTS_PREFIX = 'nodejs-docs-samples-test';
-const sinkName = generateName();
+const sinkName = `nodejs-logging-sinks-test-${uuid.v4()}`;
 const filter = 'severity > WARNING';
 const logging = new Logging();
 const storage = new Storage();
@@ -80,7 +79,3 @@ describe('sinks', () => {
     await assert.rejects(logging.sink(sinkName).getMetadata());
   });
 });
-
-function generateName() {
-  return `${TESTS_PREFIX}-${Date.now()}-${uuid.v4().split('-').pop()}`;
-}


### PR DESCRIPTION
In the [recent PR ](https://github.com/googleapis/nodejs-logging/pulls?q=is%3Apr+is%3Aclosed)all the tests was passing successfully but, `after` hook was failing.
In Document mention that  [Log entries written shortly before the delete operation might not be deleted.](https://cloud.google.com/logging/docs/reference/v2/rest/v2/logs/delete).
Modify delete logs logic in `after` now it will delete logs that has been created before 1 hr.
Fixes #761
