### PR TITLE
feat: accept entry.timestamp string input in RFC3339 format

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -177,7 +177,7 @@ class Entry {
       const nanoSecs = zuluTime.match(reNano)?.[1];
       entry.timestamp = {
         seconds: ms ? Math.floor(ms / 1000) : 0,
-        nanos: nanoSecs ? parseInt(nanoSecs.padEnd(9, '0')) : 0,
+        nanos: nanoSecs ? Number(nanoSecs.padEnd(9, '0')) : 0,
       };
     }
     return entry;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -24,7 +24,7 @@ import {objToStruct, structToObj} from './common';
 
 const eventId = new EventId();
 
-export type Timestamp = google.protobuf.ITimestamp | Date;
+export type Timestamp = google.protobuf.ITimestamp | Date | string;
 export type LogSeverity = google.logging.type.LogSeverity | string;
 export type LogEntry = Merge<
   google.logging.v2.ILogEntry,
@@ -152,6 +152,7 @@ class Entry {
    */
   toJSON(options: ToJsonOptions = {}) {
     const entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
+    // Format log message
     if (is.object(this.data)) {
       entry.jsonPayload = objToStruct(this.data, {
         removeCircular: !!options.removeCircular,
@@ -160,12 +161,23 @@ class Entry {
     } else if (is.string(this.data)) {
       entry.textPayload = this.data;
     }
+    // Format log timestamp
     if (is.date(entry.timestamp)) {
       const seconds = (entry.timestamp as Date).getTime() / 1000;
       const secondsRounded = Math.floor(seconds);
       entry.timestamp = {
         seconds: secondsRounded,
         nanos: Math.floor((seconds - secondsRounded) * 1e9),
+      };
+    } else if (is.string(entry.timestamp)) {
+      // Convert RFC3339 "Zulu" timestamp into a format that can be parsed to Date
+      const zuluTime = entry.timestamp as string;
+      const ms = Date.parse(zuluTime.split(/[.,Z]/)[0] + 'Z');
+      const reNano = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.(\d{0,9})Z$/;
+      const nanoSecs = zuluTime.match(reNano)?.[1];
+      entry.timestamp = {
+        seconds: ms ? Math.floor(ms / 1000) : 0,
+        nanos: nanoSecs ? parseInt(nanoSecs.padEnd(9, '0')) : 0,
       };
     }
     return entry;

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -212,7 +212,7 @@ describe('Entry', () => {
       assert.strictEqual(json.textPayload, entry.data);
     });
 
-    it('should convert a date', () => {
+    it('should convert a date timestamp', () => {
       const date = new Date();
       entry.metadata.timestamp = date as entryTypes.Timestamp;
       const json = entry.toJSON();
@@ -222,6 +222,40 @@ describe('Entry', () => {
         seconds: secondsRounded,
         nanos: Math.floor((seconds - secondsRounded) * 1e9),
       });
+    });
+
+    it('should convert a string timestamp', () => {
+      const tests = [
+        {
+          inputTime: '2020-01-01T00:00:00.11Z',
+          expectedSeconds: 1577836800,
+          expectedNanos: 110000000,
+        },
+        {
+          inputTime: '2020-01-01T00:00:00Z',
+          expectedSeconds: 1577836800,
+          expectedNanos: 0,
+        },
+        {
+          inputTime: '2020-01-01T00:00:00.999999999Z',
+          expectedSeconds: 1577836800,
+          expectedNanos: 999999999,
+        },
+        {
+          inputTime: 'invalid timestamp string',
+          expectedSeconds: 0,
+          expectedNanos: 0,
+        },
+      ];
+
+      for (const test of tests) {
+        entry.metadata.timestamp = test.inputTime;
+        const json = entry.toJSON();
+        assert.deepStrictEqual(json.timestamp, {
+          seconds: test.expectedSeconds,
+          nanos: test.expectedNanos,
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
Fixes #934 

Context: 
- Keeps feature parity with [API](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) 
- Users may find this useful when they need timestamp to be be higher precision than milliseconds, and want to control timestamp input themselves. 