### PR TITLE
fix!: users can log httprequest logs without providing a log message

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -425,10 +425,16 @@ class Log implements LogSeverityFunctions {
    */
   entry(metadataOrData?: LogEntry | string | {}, data?: string | {}) {
     let metadata: LogEntry;
-    if (!data) {
+    if (!data && metadataOrData?.hasOwnProperty('httpRequest')) {
+      // If user logs entry(httpRequest)
+      metadata = metadataOrData as LogEntry;
+      data = {};
+    } else if (!data) {
+      // If user logs entry(message)
       data = metadataOrData as string | {};
       metadata = {};
     } else {
+      // If user logs entry(metadata, message)
       metadata = metadataOrData as LogEntry;
     }
     return this.logging.entry(metadata, data);

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -534,6 +534,29 @@ describe('Logging', () => {
       });
     });
 
+    it.only('should write a httpRequest log with no message', done => {
+      const {log} = getTestLog();
+
+      const metadata = {
+        httpRequest: { status: 200 }
+      };
+
+      const logEntry = log.entry(metadata);
+
+      log.write(logEntry, err => {
+        assert.ifError(err);
+
+        getEntriesFromLog(log, {numExpectedMessages: 1}, (err, entries) => {
+          assert.ifError(err);
+          const entry = entries![0];
+
+          assert.strictEqual(entry.metadata.httpRequest?.status, metadata.httpRequest.status);
+          assert.deepStrictEqual(entry.data, {});
+          done();
+        });
+      });
+    });
+
     it('should set the default resource', done => {
       const {log} = getTestLog();
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -534,13 +534,11 @@ describe('Logging', () => {
       });
     });
 
-    it.only('should write a httpRequest log with no message', done => {
+    it('should write a httpRequest log with no message', done => {
       const {log} = getTestLog();
-
       const metadata = {
-        httpRequest: { status: 200 }
+        httpRequest: {status: 200},
       };
-
       const logEntry = log.entry(metadata);
 
       log.write(logEntry, err => {
@@ -550,7 +548,10 @@ describe('Logging', () => {
           assert.ifError(err);
           const entry = entries![0];
 
-          assert.strictEqual(entry.metadata.httpRequest?.status, metadata.httpRequest.status);
+          assert.strictEqual(
+            entry.metadata.httpRequest?.status,
+            metadata.httpRequest.status
+          );
           assert.deepStrictEqual(entry.data, {});
           done();
         });

--- a/test/log.ts
+++ b/test/log.ts
@@ -243,10 +243,18 @@ describe('Log', () => {
       assert(log.logging.entry.calledWithExactly(metadata, data));
     });
 
-    it('should assume one argument means data', () => {
+    it('should assume one regular argument means data', () => {
       const data = {};
       log.entry(data);
       assert(log.logging.entry.calledWith(sinon.match.any, data));
+    });
+
+    it('should assume one httpRequest argument means metadata', () => {
+      const metadata = {
+        httpRequest: {},
+      };
+      log.entry(metadata);
+      assert(log.logging.entry.calledWith(metadata, {}));
     });
   });
 


### PR DESCRIPTION
Fixes #929 🦕

According to specs and [docs](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry), users should be able to log `httpRequest` type logs independently of a log message. 

In this case, the log message (jsonPayload field) can just show up as `{}`. And of course, `jsonPayload` field should not contain the `httpRequest` data.

Note:
- Users can now log `entry(metadata.httprequest, nil)` and jsonPayload will show up as `{}`
- Users can still log `entry(nil, message)`
- Users can still log `entry(metadata, message)` - regular case
- See test cases

Solves customer issue: b/172339240

