### PR TITLE
perf!: getEntries filters 24 hour timestamp by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -462,7 +462,6 @@ class Logging {
     return new Entry(resource, data);
   }
 
-  // TODO: nicole fix this one
   getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
   getEntries(callback: GetEntriesCallback): void;
   getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,7 @@ class Logging {
     return new Entry(resource, data);
   }
 
+  // TODO: nicole fix this one
   getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
   getEntries(callback: GetEntriesCallback): void;
   getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
@@ -552,12 +553,20 @@ class Logging {
     opts?: GetEntriesRequest | GetEntriesCallback
   ): Promise<GetEntriesResponse> {
     const options = opts ? (opts as GetEntriesRequest) : {};
-    const reqOpts = extend(
-      {
-        orderBy: 'timestamp desc',
-      },
-      options
-    );
+
+    // By default, sort entries by descending timestamp
+    let reqOpts = extend({orderBy: 'timestamp desc'}, options);
+
+    // By default, filter entries to last 24 hours only
+    const time = new Date();
+    time.setDate(time.getDate() - 1);
+    const timeFilter = `timestamp >= "${time.toISOString()}"`;
+    if (!options.filter) {
+      reqOpts = extend({filter: timeFilter}, reqOpts);
+    } else if (!options.filter.includes('timestamp')) {
+      reqOpts.filter += ` AND ${timeFilter}`;
+    }
+
     reqOpts.resourceNames = arrify(reqOpts.resourceNames!);
     this.projectId = await this.auth.getProjectId();
     const resourceName = 'projects/' + this.projectId;

--- a/test/index.ts
+++ b/test/index.ts
@@ -103,12 +103,6 @@ const originalFakeUtil = extend(true, {}, fakeUtil);
 
 function fakeV2() {}
 
-function getDefaultTimeFilter(): string {
-  const time = new Date();
-  time.setDate(time.getDate() - 1);
-  return `timestamp >= "${time.toISOString()}"`;
-}
-
 class FakeEntry {
   calledWith_: IArguments;
   constructor() {
@@ -485,17 +479,19 @@ describe('Logging', () => {
 
     it('should exec without options (with defaults)', async () => {
       logging.loggingService.listLogEntries = async (
-        reqOpts: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        reqOpts: any,
         gaxOpts: {}
       ) => {
         assert.deepStrictEqual(reqOpts, {
-          filter: `${getDefaultTimeFilter()}`,
+          filter: reqOpts?.filter,
           orderBy: 'timestamp desc',
           resourceNames: ['projects/' + logging.projectId],
         });
         assert.deepStrictEqual(gaxOpts, {
           autoPaginate: undefined,
         });
+        assert.ok(reqOpts?.filter.includes('timestamp'));
         return [[]];
       };
 
@@ -531,21 +527,22 @@ describe('Logging', () => {
       const options = {filter: 'test'};
 
       logging.loggingService.listLogEntries = async (
-        reqOpts: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        reqOpts: any,
         gaxOpts: {}
       ) => {
         assert.deepStrictEqual(
           reqOpts,
           extend(options, {
-            filter: `test AND ${getDefaultTimeFilter()}`,
+            filter: reqOpts?.filter,
             orderBy: 'timestamp desc',
             resourceNames: ['projects/' + logging.projectId],
           })
         );
-
         assert.deepStrictEqual(gaxOpts, {
           autoPaginate: undefined,
         });
+        assert.ok(reqOpts?.filter.includes('test AND timestamp'));
         return [[]];
       };
 
@@ -599,13 +596,14 @@ describe('Logging', () => {
         assert.deepStrictEqual(reqOpts, {
           a: 'b',
           c: 'd',
-          filter: `${getDefaultTimeFilter()}`,
+          filter: reqOpts?.filter,
           orderBy: 'timestamp desc',
           resourceNames: ['projects/' + logging.projectId],
         });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         assert.strictEqual((reqOpts as any).gaxOptions, undefined);
         assert.deepStrictEqual(gaxOpts, options.gaxOptions);
+        assert.ok(reqOpts?.filter.includes('timestamp'));
         return [[]];
       };
 


### PR DESCRIPTION
Fixes #924 

This fix/feat is applied across client libraries in Go, Python, Java and Node, e.g.
https://github.com/googleapis/google-cloud-go/pull/3120
https://github.com/googleapis/python-logging/pull/73
