### PR TITLE
fix: only apply logName to filter when not already present

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -530,9 +530,9 @@ class Log implements LogSeverityFunctions {
     const options = extend({}, opts as GetEntriesRequest);
     const projectId = await this.logging.auth.getProjectId();
     this.formattedName_ = Log.formatName_(projectId, this.name);
-    if (options.filter) {
+    if (options.filter && !options.filter.includes('logName=')) {
       options.filter = `(${options.filter}) AND logName="${this.formattedName_}"`;
-    } else {
+    } else if (!options.filter) {
       options.filter = `logName="${this.formattedName_}"`;
     }
     return this.logging.getEntries(options);

--- a/test/log.ts
+++ b/test/log.ts
@@ -271,6 +271,14 @@ describe('Log', () => {
       await log.getEntries(options);
       assert(log.logging.getEntries.calledWithExactly(expectedOptions));
     });
+
+    it('should not add logName filter if already present', async () => {
+      const filter = `logName="${LOG_NAME_FORMATTED}" AND custom filter`;
+      const options = {filter};
+
+      await log.getEntries(options);
+      assert(log.logging.getEntries.calledWithExactly({filter}));
+    });
   });
 
   describe('getEntriesStream', () => {


### PR DESCRIPTION
RE: #943

This corrects an issue I discovered while researching #943. For convenience, we have `log.getEntries()` add a filter to the provided query, filling in the logName for the user. However, if the query already had a filter with the logName included, it would duplicate the filter condition (`logName=my-log AND logName=my-log AND ...`).

This scenario arises anytime the user calls "log.getEntries()" where there are enough results to warrant auto-pagination.