### PR TITLE
test: reenable multiple entry test with null payload value

### DIFF
--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -398,10 +398,7 @@ describe('Logging', () => {
       await log.write(logEntries[1], options);
     });
 
-    // TODO(bcoe): this appears to be an actual regression with the API that
-    // we need to dig into `nonValue` is either not being written, or not being
-    // read appropriately from the API:
-    it.skip('should write multiple entries to a log', done => {
+    it('should write multiple entries to a log', done => {
       const {log, logEntries} = getTestLog();
 
       log.write(logEntries, options, err => {


### PR DESCRIPTION
Fixes #818 

I re-enabled this test as null values are getting returned now. 