### PR TITLE
fix: synth.py pipeline

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -24,8 +24,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
-s.metadata.set_track_obsolete_files(False)
-
 gapic = gcp.GAPICBazel()
 version='v2'
 # tasks has two product names, and a poorly named artman yaml

--- a/synth.py
+++ b/synth.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
-s.metadata.set_track_obsolete_files(True)
+s.metadata.set_track_obsolete_files(False)
 
 gapic = gcp.GAPICBazel()
 version='v2'


### PR DESCRIPTION
This turns off set_track_obsolete_files for the synth file, fixing the synthtool build pipeline. I added a bit more information describing the issue in the related [synthtool bug](https://github.com/googleapis/synthtool/issues/891):

> I did a bit more research into this. It looks like the issue is caused because SYNTHTOOL_TRACK_OBSOLETE_FILES defaults to False, then it is enabled as part of the synth.py file. This means when MetadataTrackerAndWriter is exited, should_track_obsolete_files has a different value than when it was entered.
>
> A solution seems to be to enable the flag before MetadataTrackerAndWriter is entered, but that seems to be before the synth.py file is called. For now, I'm going to turn set_track_obsolete_files off for the logging library

I'm not sure about all the consequences of disabling this option, so we should check in with the Yoshi team before merging

Fixes https://github.com/googleapis/nodejs-logging/issues/975
