### PR TITLE
chore: add env-test-logging submodule directly to repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "env-tests-logging"]
 	path = env-tests-logging
 	url = https://github.com/googleapis/env-tests-logging
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "env-tests-logging"]
+	path = env-tests-logging
+	url = https://github.com/googleapis/env-tests-logging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,20 @@ accept your pull requests.
 
         npm run fix
 
+## Running the tests in GCP services
+
+It is possible to end-to-end test this library within specific Google Cloud
+Platform environments. The [env-tests-logging](https://github.com/googleapis/env-tests-logging)
+submodule contains common tests to ensure correct logging behavior across Google 
+Cloud Platforms.
+
+Currently, the following environments are supported:
+
+| Platform        | Runtime        | Try it                         |
+| --------------- | -------------- | ------------------------------ |
+| Cloud Functions | Nodejs12       | `nox --session "tests(language='nodejs', platform='functions')"` |
+| Cloud Run       | COMING SOON    | `nox --session "tests(language='nodejs', platform='cloudrun')"` |
+
 [setup]: https://cloud.google.com/nodejs/docs/setup
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing


### PR DESCRIPTION
Adding submodule directly to repo s.t. external contributors can optionally use it