### PR TITLE
fix(deps): drop dependency on type-fest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "pumpify": "^2.0.1",
     "snakecase-keys": "^3.1.2",
     "stream-events": "^1.0.5",
-    "through2": "^4.0.0",
-    "type-fest": "^0.21.0"
+    "through2": "^4.0.0"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.0.0",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -26,8 +26,8 @@ const eventId = new EventId();
 export type Timestamp = google.protobuf.ITimestamp | Date | string;
 export type LogSeverity = google.logging.type.LogSeverity | string;
 export type LogEntry = Omit<
-  Omit<google.logging.v2.ILogEntry, 'timestamp'>,
-  'severity'
+  google.logging.v2.ILogEntry,
+  'timestamp' | 'severity'
 > & {
   timestamp?: Timestamp | null;
   severity?: LogSeverity | null;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Merge} from 'type-fest';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const EventId = require('eventid');
 import * as extend from 'extend';
@@ -26,13 +25,14 @@ const eventId = new EventId();
 
 export type Timestamp = google.protobuf.ITimestamp | Date | string;
 export type LogSeverity = google.logging.type.LogSeverity | string;
-export type LogEntry = Merge<
-  google.logging.v2.ILogEntry,
-  {
-    timestamp?: Timestamp | null;
-    severity?: LogSeverity | null;
-  }
->;
+export type LogEntry = Omit<
+  Omit<google.logging.v2.ILogEntry, 'timestamp'>,
+  'severity'
+> & {
+  timestamp?: Timestamp | null;
+  severity?: LogSeverity | null;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Data = any;
 


### PR DESCRIPTION
As far as I can tell, we don't really need `type-fest` here.  The only usage was just omitting two types from an interface, and then re-defining their type.  TypeScript has built in `Omit`, and I think this does the same thing.  Trying to reduce our dependencies. 