### PR TITLE
feat: resource autodetection for cloud run

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -56,10 +56,13 @@ export function getCloudFunctionDescriptor() {
  *
  * @returns {object}
  */
-export function getCloudRunDescriptor() {
+export async function getCloudRunDescriptor() {
+  const qualifiedZone = await gcpMetadata.instance('zone');
+  const location = zoneFromQualifiedZone(qualifiedZone);
   return {
     type: 'cloud_run_revision',
     labels: {
+      location,
       service_name: process.env.K_SERVICE,
       revision_name: process.env.K_REVISION,
       configuration_name: process.env.K_CONFIGURATION,
@@ -172,7 +175,7 @@ export async function getDefaultResource(auth: GoogleAuth) {
     case GCPEnv.COMPUTE_ENGINE:
       //  Google Cloud Run
       if (process.env.K_CONFIGURATION) {
-        return getCloudRunDescriptor();
+        return getCloudRunDescriptor().catch(() => getGlobalDescriptor());
       } else {
         // Test for compute engine should be done after all the rest -
         // everything runs on top of compute engine.

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -213,6 +213,13 @@ export async function detectServiceContext(
     // name from within the pod.
     case GCPEnv.KUBERNETES_ENGINE:
     case GCPEnv.COMPUTE_ENGINE:
+      // Google Cloud Run
+      if (process.env.K_CONFIGURATION) {
+        return {
+          service: process.env.K_SERVICE,
+        };
+      }
+      return null;
     default:
       return null;
   }

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -152,6 +152,34 @@ describe('metadata', () => {
     });
   });
 
+  describe('getCloudRunDescriptor', () => {
+    const K_SERVICE = 'hello-world';
+    const K_REVISION = 'hello-world.1';
+    const K_CONFIGURATION = 'hello_world';
+
+    beforeEach(() => {
+      process.env.K_SERVICE = K_SERVICE;
+      process.env.K_REVISION = K_REVISION;
+      process.env.K_CONFIGURATION = K_CONFIGURATION;
+    });
+
+    it('should return the correct descriptor', async () => {
+      const ZONE_ID = 'cyrodiil-anvil-2';
+      const ZONE_FULL = `projects/fake-project/zones/${ZONE_ID}`;
+      instanceOverride = {path: 'zone', successArg: ZONE_FULL};
+      const descriptor = await metadata.getCloudRunDescriptor();
+      assert.deepStrictEqual(descriptor, {
+        type: 'cloud_run_revision',
+        labels: {
+          service_name: K_SERVICE,
+          revision_name: K_REVISION,
+          configuration_name: K_CONFIGURATION,
+          location: ZONE_ID,
+        },
+      });
+    });
+  });
+
   describe('getGAEDescriptor', () => {
     const GAE_MODULE_NAME = 'gae-module-name';
     const GAE_SERVICE = 'gae-service';

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -550,6 +550,23 @@ describe('metadata', () => {
       assert.deepStrictEqual(sc1, {service: FUNCTION_NAME});
     });
 
+    it('should return the correct descriptor for Cloud Run', async () => {
+      process.env.K_CONFIGURATION = 'hello-world';
+      const SERVICE_NAME = (process.env.K_SERVICE = 'hello-world');
+
+      const fakeAuth = {
+        async getEnv() {
+          return GCPEnv.COMPUTE_ENGINE;
+        },
+      };
+
+      const sc1 = await metadata.detectServiceContext(fakeAuth);
+      assert.deepStrictEqual(sc1, {service: SERVICE_NAME});
+
+      delete process.env['K_CONFIGURATION'];
+      delete process.env['K_SERVICE'];
+    });
+
     it('should return null on GKE', async () => {
       const fakeAuth = {
         async getEnv() {

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -68,6 +68,8 @@ describe('metadata', () => {
   let AUTH;
   const ENV_CACHED = extend({}, process.env);
 
+  const INITIAL_ENV: {[key: string]: string | undefined} = {};
+
   before(() => {
     metadata = proxyquire('../src/metadata', {
       'gcp-metadata': fakeGcpMetadata,
@@ -101,7 +103,6 @@ describe('metadata', () => {
       'K_SERVICE',
       'GOOGLE_CLOUD_REGION',
     ];
-    const INITIAL_ENV: {[key: string]: string | undefined} = {};
 
     before(() => {
       for (const key of TARGET_KEYS) {
@@ -155,9 +156,31 @@ describe('metadata', () => {
   describe('getCloudRunDescriptor', () => {
     const K_SERVICE = 'hello-world';
     const K_REVISION = 'hello-world.1';
-    const K_CONFIGURATION = 'hello_world';
+    const K_CONFIGURATION = 'hello-world';
+
+    const TARGET_KEYS = ['K_SERVICE', 'K_REVISION', 'K_CONFIGURATION'];
+
+    before(() => {
+      for (const key of TARGET_KEYS) {
+        INITIAL_ENV[key] = process.env[key];
+      }
+    });
+
+    after(() => {
+      for (const key of TARGET_KEYS) {
+        const val = INITIAL_ENV[key];
+        if (val === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = val;
+        }
+      }
+    });
 
     beforeEach(() => {
+      for (const key of TARGET_KEYS) {
+        delete process.env[key];
+      }
       process.env.K_SERVICE = K_SERVICE;
       process.env.K_REVISION = K_REVISION;
       process.env.K_CONFIGURATION = K_CONFIGURATION;
@@ -325,6 +348,47 @@ describe('metadata', () => {
             labels: {
               function_name: FUNCTION_NAME,
               region: FUNCTION_REGION,
+            },
+          });
+        });
+      });
+
+      describe('cloud run', () => {
+        after(() => {
+          delete process.env['K_CONFIGURATION'];
+          delete process.env['K_REVISION'];
+          delete process.env['K_SERVICE'];
+        });
+
+        it('should return correct descriptor', async () => {
+          const K_SERVICE = 'hello-world';
+          const K_CONFIGURATION = 'hello-world';
+          const K_REVISION = 'hello-world.1';
+          const ZONE_ID = 'cyrodiil-anvil-2';
+          const ZONE_FULL = `projects/fake-project/zones/${ZONE_ID}`;
+          process.env.K_SERVICE = K_SERVICE;
+          process.env.K_REVISION = K_REVISION;
+          process.env.K_CONFIGURATION = K_CONFIGURATION;
+          instanceOverride = [
+            {
+              path: 'zone',
+              successArg: ZONE_FULL,
+            },
+          ];
+          const fakeAuth = {
+            async getEnv() {
+              return GCPEnv.COMPUTE_ENGINE;
+            },
+          };
+
+          const defaultResource = await metadata.getDefaultResource(fakeAuth);
+          assert.deepStrictEqual(defaultResource, {
+            type: 'cloud_run_revision',
+            labels: {
+              service_name: K_SERVICE,
+              revision_name: K_REVISION,
+              configuration_name: K_CONFIGURATION,
+              location: ZONE_ID,
             },
           });
         });


### PR DESCRIPTION
Fixes #959 🦕

Changes:
- [x] User logs to CloudRun automatically contain [resource labels per contract](https://cloud.google.com/run/docs/reference/container-contract?hl=lt#env-vars)
- [x] Unit tests pass 
- [x] End-to-end environment tests pass with correct resource types/labels. To repro: run `nox --python 3.7 --session "tests(language='nodejs', platform=‘cloudrun’)”` in `/env-tests-logging`

Get 
```sh
nox > Running session tests(language='nodejs', platform='cloudrun')
nox > Creating virtual environment (virtualenv) using python3.7 in .nox/tests-language-nodejs-platform-cloudrun
nox > python -m pip install --pre grpcio
nox > python -m pip install mock pytest google-cloud-testutils google-cloud-bigquery google-cloud-pubsub google-cloud-storage google-cloud-testutils google-cloud-logging
nox > py.test -s ./tests/nodejs/test_cloudrun.py
======================================================== test session starts ========================================================
platform darwin -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging
collected 3 items

tests/nodejs/test_cloudrun.py ['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'verify']
['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'deploy']
['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'verify']
['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'trigger', 'simplelog', 'log_text="test_monitored_resource 5e611698-9406-11eb-82d3-3e22fb28907a"']
, Trying again in 2 seconds...
['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'trigger', 'simplelog', 'log_text="test_monitored_resource 89883162-9406-11eb-82d3-3e22fb28907a"']
.['/Users/nicolezhu/Desktop/nodejs-logging/env-tests-logging/envctl/envctl', 'nodejs', 'cloudrun', 'trigger', 'simplelog', 'log_text="test_receive_log 939056b2-9406-11eb-82d3-3e22fb28907a"']
..

=================================================== 3 passed in 172.87s (0:02:52) ===================================================
nox > Session tests(language='nodejs', platform='cloudrun') was successful.
```
Before: 
![image](https://user-images.githubusercontent.com/69952136/113459303-ef740600-93c9-11eb-9693-9d740c09c22a.png)

After: 
![Screen Shot 2021-04-02 at 3 46 03 PM](https://user-images.githubusercontent.com/69952136/113459496-89d44980-93ca-11eb-8870-34d3da63b783.png)

