### PR TITLE
fix: accept uniqueWriterIdentity in setMetadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export interface CreateSinkRequest {
   includeChildren?: boolean;
   name?: string;
   outputVersionFormat?: google.logging.v2.LogSink.VersionFormat;
-  uniqueWriterIdentity?: string;
+  uniqueWriterIdentity?: string | boolean;
   gaxOptions?: gax.CallOptions;
 }
 
@@ -316,7 +316,7 @@ class Logging {
    * https://cloud.google.com/nodejs/docs/reference/pubsub/latest/Topic Topic}
    * @property {string} [filter] An advanced logs filter. Only log entries
    *     matching the filter are written.
-   * @property {string} [uniqueWriterIdentity] Determines the kind of IAM
+   * @property {string|boolean} [uniqueWriterIdentity] Determines the kind of IAM
    *     identity returned as `writerIdentity` in the new sink. See {@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/create#query-parameters}.
    */
   /**

--- a/src/sink.ts
+++ b/src/sink.ts
@@ -290,8 +290,10 @@ class Sink {
   /**
    * Set the sink's metadata.
    *
-   * Note: If the sink was created with uniqueWriterIdentity = true, then the
-   * sink must be updated with uniqueWriterIdentity = true.
+   * Note: If the sink was previously created or updated with
+   * uniqueWriterIdentity = true, then you must update the sink by setting
+   * uniqueWriterIdentity = true. Read more about using a unique writer identity
+   * here: https://cloud.google.com/logging/docs/api/tasks/exporting-logs#using_a_unique_writer_identity
    *
    * @see [Sink Resource]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink}
    * @see [projects.sink.update API Documentation]{@link https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks/update}

--- a/src/sink.ts
+++ b/src/sink.ts
@@ -34,6 +34,8 @@ export type SinkMetadataResponse = [LogSink];
 
 export interface SetSinkMetadata extends LogSink {
   gaxOptions?: CallOptions;
+  // A unique service account just for the sink
+  // https://cloud.google.com/logging/docs/api/tasks/exporting-logs#using_a_unique_writer_identity
   uniqueWriterIdentity?: boolean | string;
 }
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -196,6 +196,9 @@ describe('Logging', () => {
         };
         const [apiResponse] = await sink.setMetadata(metadata);
         assert.strictEqual(apiResponse.filter, FILTER);
+        // Sink must be deleted within this test before any logs are generated
+        // to avoid topic_permission_denied emails.
+        await sink.delete();
       });
 
       it('should set uniqueWriterIdentity from false to true', async () => {
@@ -210,6 +213,9 @@ describe('Logging', () => {
         };
         const [apiResponse] = await sink.setMetadata(metadata);
         assert.strictEqual(apiResponse.filter, FILTER);
+        // Sink must be deleted within this test before any logs are generated
+        // to avoid topic_permission_denied emails.
+        await sink.delete();
       });
     });
 

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -182,6 +182,37 @@ describe('Logging', () => {
       });
     });
 
+    describe('metadata with uniqueWriterIdentity', () => {
+      it('should set metadata if uniqueWriterIdentity was true', async () => {
+        const sink = logging.sink(generateName());
+        const FILTER = 'severity = ALERT';
+        await sink.create({
+          destination: topic,
+          uniqueWriterIdentity: true,
+        });
+        const metadata = {
+          filter: FILTER,
+          uniqueWriterIdentity: true,
+        };
+        const [apiResponse] = await sink.setMetadata(metadata);
+        assert.strictEqual(apiResponse.filter, FILTER);
+      });
+
+      it('should set uniqueWriterIdentity from false to true', async () => {
+        const sink = logging.sink(generateName());
+        const FILTER = 'severity = ALERT';
+        await sink.create({
+          destination: topic,
+        });
+        const metadata = {
+          filter: FILTER,
+          uniqueWriterIdentity: true,
+        };
+        const [apiResponse] = await sink.setMetadata(metadata);
+        assert.strictEqual(apiResponse.filter, FILTER);
+      });
+    });
+
     describe('listing sinks', () => {
       const sink = logging.sink(generateName());
 


### PR DESCRIPTION
[Final Spec](https://docs.google.com/document/d/1Uzoa-7YTahpA7HwDY0P-CobJ6UccjSSqBqNFBdS3XCU/edit?usp=sharing) (internal googler link). Fixes: [b/183619158](https://buganizer.corp.google.com/issues/183619158)

Changes: 
- Users can provide uniqueWriterIdentity boolean in setmetadata
- Users can change sink into a uniqueWriterIdentity, from a shared identity