### PR TITLE
build: release minified package as dist-tag `min`

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -28,14 +28,4 @@ NPM_TOKEN=$(cat $KOKORO_GFILE_DIR/secret_manager/npm_publish_token)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install
-
-# Publish the regular package
 npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
-
-# Publish the minified package
-export PUBLISH_MIN=true
-npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
-NEW_MIN_VERSION=$(node -pe "require('./package.json').version")
-# Update the 'min' distro tag to latest min version
-npm dist-tag rm 'min' 2> /dev/null
-npm dist-tag add @google-cloud/logging@$NEW_MIN_VERSION min

--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -34,5 +34,8 @@ npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
 
 # Publish the minified package
 export PUBLISH_MIN=true
-
-#npm publish (dist tag = 'min')
+npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
+NEW_MIN_VERSION=$(node -pe "require('./package.json').version")
+# Update the 'min' distro tag to latest min version
+npm dist-tag rm 'min' 2> /dev/null
+npm dist-tag add @google-cloud/logging@$NEW_MIN_VERSION min

--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -28,4 +28,11 @@ NPM_TOKEN=$(cat $KOKORO_GFILE_DIR/secret_manager/npm_publish_token)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install
+
+# Publish the regular package
 npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
+
+# Publish the minified package
+export PUBLISH_MIN=true
+
+#npm publish (dist tag = 'min')

--- a/.kokoro/publishmin.sh
+++ b/.kokoro/publishmin.sh
@@ -31,31 +31,17 @@ if [ "$PUBLISH_MIN" = true ] ; then
     popd
   done
 
-  # Update package.json version to min version
-  # get published min library version... e.g. 10.0.0-min.0
-  PUBLISHED_MIN_VERSION=$(npm dist-tag ls) | sed 's/\ /\n/g' | sed -n '/min:/{n;p;}'
-  PUBLISHED_MIN_VERSION_PREFIX=PUBLISHED_MIN_VERSION | sed 's/-min.*//'
-  PUBLISHED_MIN_VERSION_SUFFIX=PUBLISHED_MIN_VERSION | sed 's/.*-min.//'
+  # Get current published min library version, e.g. 10.0.0-min.0
+  PUBLISHED_MIN=$(npm dist-tag ls) | sed 's/\ /\n/g' | sed -n '/min:/{n;p;}'
+  PUBLISHED_MIN_PREFIX=PUBLISHED_MIN | sed 's/-min.*//'
+  PUBLISHED_MIN_SUFFIX=PUBLISHED_MIN | sed 's/.*-min.//'
   LOCAL_VERSION=$(node -pe "require('./package.json').version")
 
-  if [ "$PUBLISHED_MIN_VERSION_PREFIX" == "$LOCAL_VERSION" ]; then
-    # Then only the min package is getting updated
-    nvm version PUBLISHED_MIN_VERSION_PREFIX-min......
+  if [ "$PUBLISHED_MIN_PREFIX" == "$LOCAL_VERSION" ]; then
+    # Patch the `min` distro, e.g. 10.0.0-min.1
+    nvm version $PUBLISHED_MIN_VERSION-min.$(($PUBLISHED_MIN_SUFFIX + 1))
   else
-    # `min` distro is releasing alongside a `latest` release
+    # Release a new `min` distro version, e.g. 10.0.1-min.0
     nvm version $LOCAL_VERSION-min.0
   fi
-
-
-
-  nvm version 1.1.1-min.0
-
-  # if master library version is different than current min. set
-
-  #  if master library version is same, just increment the library patch version.
-
-  # remove old tag if any
-  # tag new distro with "min"
-  npm dist-tag add @google-cloud/logging@10.0.0-min.0 min
-
 fi

--- a/.kokoro/publishmin.sh
+++ b/.kokoro/publishmin.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set +ex
 
 # Only run this script if envvar PUBLISH_MIN indicates we're publishing the
@@ -16,14 +31,31 @@ if [ "$PUBLISH_MIN" = true ] ; then
     popd
   done
 
-  # Update package version to min version
-  npm version 10.0.0-min.0
+  # Update package.json version to min version
+  # get published min library version... e.g. 10.0.0-min.0
+  PUBLISHED_MIN_VERSION=$(npm dist-tag ls) | sed 's/\ /\n/g' | sed -n '/min:/{n;p;}'
+  PUBLISHED_MIN_VERSION_PREFIX=PUBLISHED_MIN_VERSION | sed 's/-min.*//'
+  PUBLISHED_MIN_VERSION_SUFFIX=PUBLISHED_MIN_VERSION | sed 's/.*-min.//'
+  LOCAL_VERSION=$(node -pe "require('./package.json').version")
 
-#  # Update dist-tags
-#  npm dist-tag ls [<pkg>]
-#
-#  npm dist-tag add <pkg>@<version> [<tag>]
-# edit package.json version to 1.1.1.min
-  # remove previous tag, increment it, or if normal version is the same, increment the last num. npm dist-tag rm <pkg> <tag>
+  if [ "$PUBLISHED_MIN_VERSION_PREFIX" == "$LOCAL_VERSION" ]; then
+    # Then only the min package is getting updated
+    nvm version PUBLISHED_MIN_VERSION_PREFIX-min......
+  else
+    # `min` distro is releasing alongside a `latest` release
+    nvm version $LOCAL_VERSION-min.0
+  fi
+
+
+
+  nvm version 1.1.1-min.0
+
+  # if master library version is different than current min. set
+
+  #  if master library version is same, just increment the library patch version.
+
+  # remove old tag if any
+  # tag new distro with "min"
+  npm dist-tag add @google-cloud/logging@10.0.0-min.0 min
 
 fi

--- a/.kokoro/publishmin.sh
+++ b/.kokoro/publishmin.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set +ex
+
+# Only run this script if envvar PUBLISH_MIN indicates we're publishing the
+# minified distribution.
+if [ "$PUBLISH_MIN" = true ] ; then
+  # Minify all subdirectories in /build
+  for d in $(find ./build/ -maxdepth 8 -type d)
+  do
+    pushd $d
+      for f in *.js; do
+        [ -f "$f" ] || break
+        # uglify all .js files
+        uglifyjs "$f" --output "$f"
+      done
+    popd
+  done
+
+  # Update package version to min version
+  npm version 10.0.0-min.0
+
+#  # Update dist-tags
+#  npm dist-tag ls [<pkg>]
+#
+#  npm dist-tag add <pkg>@<version> [<tag>]
+# edit package.json version to 1.1.1.min
+  # remove previous tag, increment it, or if normal version is the same, increment the last num. npm dist-tag rm <pkg> <tag>
+
+fi

--- a/owlbot.py
+++ b/owlbot.py
@@ -19,14 +19,16 @@ import synthtool.languages.node as node
 
 node.owlbot_main(
     staging_excludes=[
-        ".eslintignore", ".prettierignore", "src/index.ts", "README.md", "package.json",
+        ".eslintignore", ".prettierignore", "src/index.ts", "README.md",
+        "package.json", "tsconfig.json",
         "system-test/fixtures/sample/src/index.js",
         "system-test/fixtures/sample/src/index.ts"],
     templates_excludes=[
         "src/index.ts",
         ".eslintignore",
         ".prettierignore",
-        "CONTRIBUTING.md"
+        "CONTRIBUTING.md",
+        "tsconfig.json",
     ]
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/logging",
-  "version": "9.2.1",
+  "version": "10.0.0-min.0",
   "description": "Stackdriver Logging Client Library for Node.js",
   "keywords": [
     "google apis client",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/logging",
-  "version": "10.0.0-min.0",
+  "version": "9.2.1",
   "description": "Stackdriver Logging Client Library for Node.js",
   "keywords": [
     "google apis client",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prelint": "cd samples; npm link ../; npm install",
     "lint": "gts check",
     "prepare": "npm run compile-protos && npm run compile",
+    "prepublishOnly": "./.kokoro/publishmin.sh",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test --timeout 600000",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "google-gax": "^2.9.2",
     "on-finished": "^2.3.0",
     "pumpify": "^2.0.1",
-    "stream-events": "^1.0.5"
+    "stream-events": "^1.0.5",
+    "uglify-js": "^3.13.4"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": ".",
     "outDir": "build",
     "resolveJsonModule": true,
+    "sourceMap": false,
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
Fixes #1037  🦕

**Changes:** 
- Modified publish.sh to also publish a minified distro under dist-tag `min`.
- Drop sourcemaps from regular package (not just minified package). [Rationale](https://github.com/googleapis/nodejs-logging/issues/1046)

**Normal packages would still publish as:** 
Version: 1.1.1 
Tag: latest

**In tandem, min distributions would publish as:** 
Version: 1.1.1-min.0
Tag: min

Open Questions: 
- Do we need webpack / webpack-cli? what is it usedfor?
- Should I rename uglified files to x.min.js and change package path references accordingly?
