### PR TITLE
feat: fix resource autodetection for GKE, GAE, and GCE

### DIFF
--- a/.kokoro/environment/appengine_standard.cfg
+++ b/.kokoro/environment/appengine_standard.cfg
@@ -1,0 +1,11 @@
+# Specify which tests to run
+env_vars: {
+    key: "ENVIRONMENT"
+    value: "appengine_standard"
+}
+
+# TODO: actually use this variable somewhere
+env_vars: {
+    key: "RUNTIME"
+    value: "nodejs12"
+}

--- a/.kokoro/environment/compute.cfg
+++ b/.kokoro/environment/compute.cfg
@@ -1,0 +1,11 @@
+# Specify which tests to run
+env_vars: {
+    key: "ENVIRONMENT"
+    value: "compute"
+}
+
+# TODO: actually use this variable somewhere
+env_vars: {
+    key: "RUNTIME"
+    value: "nodejs12"
+}

--- a/.kokoro/environment/kubernetes.cfg
+++ b/.kokoro/environment/kubernetes.cfg
@@ -1,0 +1,11 @@
+# Specify which tests to run
+env_vars: {
+    key: "ENVIRONMENT"
+    value: "kubernetes"
+}
+
+# TODO: actually use this variable somewhere
+env_vars: {
+    key: "RUNTIME"
+    value: "nodejs12"
+}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -156,7 +156,6 @@ export async function getGKEDescriptor() {
     );
   }
 
-  // TODO: Add container_name once available - pending b/145137070.
   return {
     type: 'k8s_container',
     labels: {
@@ -164,6 +163,9 @@ export async function getGKEDescriptor() {
       cluster_name: resp,
       namespace_name: namespace,
       pod_name: process.env.HOSTNAME,
+      // Users must manually supply container name for now.
+      // This may be autodetected pending b/145137070.
+      container_name: process.env.CONTAINER_NAME,
     },
   };
 }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -145,7 +145,8 @@ export async function getGKEDescriptor() {
   // with metrics may not necessarily work however.
   //
   const resp = await gcpMetadata.instance('attributes/cluster-name');
-
+  const qualifiedZone = await gcpMetadata.instance('zone');
+  const location = regionFromQualifiedZone(qualifiedZone);
   let namespace;
   try {
     namespace = await readFile(KUBERNETES_NAMESPACE_ID_PATH, 'utf8');
@@ -155,11 +156,14 @@ export async function getGKEDescriptor() {
     );
   }
 
+  // TODO: Add container_name once available - pending b/145137070.
   return {
     type: 'k8s_container',
     labels: {
+      location,
       cluster_name: resp,
       namespace_name: namespace,
+      pod_name: process.env.HOSTNAME,
     },
   };
 }
@@ -190,7 +194,7 @@ export async function getDefaultResource(auth: GoogleAuth) {
     case GCPEnv.CLOUD_FUNCTIONS:
       return getCloudFunctionDescriptor().catch(() => getGlobalDescriptor());
     case GCPEnv.COMPUTE_ENGINE:
-      //  Google Cloud Run
+      //  Note: GCPEnv.COMPUTE_ENGINE returns `true` for Google Cloud Run
       if (process.env.K_CONFIGURATION) {
         return getCloudRunDescriptor().catch(() => getGlobalDescriptor());
       } else {
@@ -225,10 +229,12 @@ export async function detectServiceContext(
       return {
         service: process.env.FUNCTION_NAME,
       };
-    // One Kubernetes we probably need to use the pod-name to describe the
-    // service. Currently there isn't a universal way to acquire the pod
-    // name from within the pod.
+    // On Kubernetes we use the pod-name to describe the service. Currently,
+    // we acquire the pod name from within the pod through env var `HOSTNAME`.
     case GCPEnv.KUBERNETES_ENGINE:
+      return {
+        service: process.env.HOSTNAME,
+      };
     case GCPEnv.COMPUTE_ENGINE:
       // Google Cloud Run
       if (process.env.K_CONFIGURATION) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -164,7 +164,7 @@ export async function getGKEDescriptor() {
       namespace_name: namespace,
       pod_name: process.env.HOSTNAME,
       // Users must manually supply container name for now.
-      // This may be autodetected pending b/145137070.
+      // This may be autodetected in the future, pending b/145137070.
       container_name: process.env.CONTAINER_NAME,
     },
   };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -146,7 +146,7 @@ export async function getGKEDescriptor() {
   //
   const resp = await gcpMetadata.instance('attributes/cluster-name');
   const qualifiedZone = await gcpMetadata.instance('zone');
-  const location = regionFromQualifiedZone(qualifiedZone);
+  const location = zoneFromQualifiedZone(qualifiedZone);
   let namespace;
   try {
     namespace = await readFile(KUBERNETES_NAMESPACE_ID_PATH, 'utf8');
@@ -230,7 +230,7 @@ export async function detectServiceContext(
         service: process.env.FUNCTION_NAME,
       };
     // On Kubernetes we use the pod-name to describe the service. Currently,
-    // we acquire the pod name from within the pod through env var `HOSTNAME`.
+    // we acquire the pod-name from within the pod through env var `HOSTNAME`.
     case GCPEnv.KUBERNETES_ENGINE:
       return {
         service: process.env.HOSTNAME,

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -257,18 +257,35 @@ describe('metadata', () => {
   describe('getGKEDescriptor', () => {
     const CLUSTER_NAME = 'gke-cluster-name';
 
-    it('should return the correct descriptor', async () => {
-      instanceOverride = {
-        path: 'attributes/cluster-name',
-        successArg: CLUSTER_NAME,
-      };
+    beforeEach(() => {
+      process.env.HOSTNAME = 'node-gke-123';
+    });
 
+    afterEach(() => {
+      delete process.env.HOSTNAME;
+    });
+
+    it('should return the correct descriptor', async () => {
+      const ZONE_ID = 'cyrodiil-anvil-2';
+      const ZONE_FULL = `projects/fake-project/zones/${ZONE_ID}`;
+      instanceOverride = [
+        {
+          path: 'attributes/cluster-name',
+          successArg: CLUSTER_NAME,
+        },
+        {
+          path: 'zone',
+          successArg: ZONE_FULL,
+        },
+      ];
       const descriptor = await metadata.getGKEDescriptor();
       assert.deepStrictEqual(descriptor, {
         type: 'k8s_container',
         labels: {
           cluster_name: CLUSTER_NAME,
           namespace_name: FAKE_READFILE_CONTENTS,
+          location: ZONE_ID,
+          pod_name: 'node-gke-123',
         },
       });
     });
@@ -478,25 +495,36 @@ describe('metadata', () => {
       describe('container engine', () => {
         it('should return correct descriptor', async () => {
           const CLUSTER_NAME = 'overridden-value';
-          instanceOverride = {
-            path: 'attributes/cluster-name',
-            successArg: CLUSTER_NAME,
-          };
+          const ZONE_ID = 'cyrodiil-anvil-2';
+          const ZONE_FULL = `projects/fake-project/zones/${ZONE_ID}`;
+          instanceOverride = [
+            {
+              path: 'attributes/cluster-name',
+              successArg: CLUSTER_NAME,
+            },
+            {
+              path: 'zone',
+              successArg: ZONE_FULL,
+            },
+          ];
 
           const fakeAuth = {
             async getEnv() {
               return GCPEnv.KUBERNETES_ENGINE;
             },
           };
-
+          process.env.HOSTNAME = 'node-gke-123';
           const defaultResource = await metadata.getDefaultResource(fakeAuth);
           assert.deepStrictEqual(defaultResource, {
             type: 'k8s_container',
             labels: {
+              location: ZONE_ID,
+              pod_name: 'node-gke-123',
               cluster_name: CLUSTER_NAME,
               namespace_name: FAKE_READFILE_CONTENTS,
             },
           });
+          delete process.env.HOSTNAME;
         });
       });
 
@@ -584,14 +612,18 @@ describe('metadata', () => {
       delete process.env['K_SERVICE'];
     });
 
-    it('should return null on GKE', async () => {
+    it('should return the correct descriptor for GKE', async () => {
       const fakeAuth = {
         async getEnv() {
           return GCPEnv.KUBERNETES_ENGINE;
         },
       };
+      process.env.HOSTNAME = 'node-gke-123';
       const serviceContext = await metadata.detectServiceContext(fakeAuth);
-      assert.strictEqual(serviceContext, null);
+      assert.deepStrictEqual(serviceContext, {
+        service: 'node-gke-123',
+      });
+      delete process.env.HOSTNAME;
     });
 
     it('should return null on GCE', async () => {

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -259,10 +259,12 @@ describe('metadata', () => {
 
     beforeEach(() => {
       process.env.HOSTNAME = 'node-gke-123';
+      process.env.CONTAINER_NAME = 'my-container';
     });
 
     afterEach(() => {
       delete process.env.HOSTNAME;
+      delete process.env.CONTAINER_NAME;
     });
 
     it('should return the correct descriptor', async () => {
@@ -286,6 +288,7 @@ describe('metadata', () => {
           namespace_name: FAKE_READFILE_CONTENTS,
           location: ZONE_ID,
           pod_name: 'node-gke-123',
+          container_name: 'my-container',
         },
       });
     });
@@ -514,6 +517,7 @@ describe('metadata', () => {
             },
           };
           process.env.HOSTNAME = 'node-gke-123';
+          process.env.CONTAINER_NAME = 'my-container';
           const defaultResource = await metadata.getDefaultResource(fakeAuth);
           assert.deepStrictEqual(defaultResource, {
             type: 'k8s_container',
@@ -522,9 +526,10 @@ describe('metadata', () => {
               pod_name: 'node-gke-123',
               cluster_name: CLUSTER_NAME,
               namespace_name: FAKE_READFILE_CONTENTS,
+              container_name: 'my-container',
             },
           });
-          delete process.env.HOSTNAME;
+          delete process.env.CONTAINER_NAME;
         });
       });
 


### PR DESCRIPTION
Fixes #673  🦕
Fixes #125  🦕

For GKE, we infer the following after thorough discussion and research: 
- `pod_name` == `process.env.HOSTNAME`
- `namespace_name` == fs/readfile() `~/var/run/secrets/kubernetes.io/serviceaccount/namespace`
- `container_name` is only populated if users pass it into containers as an environment variable. Not available via any downwards APIs or GCP apis for now.

Passing e2e environment tests that verify logging behavior in respective platforms: 
- prod:cloud-devrel/client-libraries/go/google-cloud-go/environment/logging/compute
- prod:cloud-devrel/client-libraries/go/google-cloud-go/environment/logging/appengine_standard
- prod:cloud-devrel/client-libraries/go/google-cloud-go/environment/logging/kubernetes