### PR TITLE
chore: fix endless publishing loop

### DIFF
--- a/.kokoro/publish-min.sh
+++ b/.kokoro/publish-min.sh
@@ -42,4 +42,5 @@ if [ -f "package.json-e" ]; then
   rm package.json-e
 fi
 
-npm publish --access=public --registry=https://wombat-dressing-room.appspot.com
+# Note: ignore the postpublish script here to avoid an endless publish loop.
+npm publish --ignore-scripts --access=public --registry=https://wombat-dressing-room.appspot.com


### PR DESCRIPTION
Open question: What should we name this new minified package? That potentially* has reduced features in the future?
Writeup with more details here: go/nodejs-logging-lite

Currently I have it as logging-min. Other name ideas: 
- @google-cloud/logging-tiny
- @google-cloud/logging-lite
- @google-cloud/logging-reduced
- @google-cloud/logging-small
- @google-cloud/logging-min
- @google-cloud/logging-serverless
- @google-cloud/logging-mini

