### PR TITLE
feat: users can log formatted HTTPRequests

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -902,7 +902,7 @@ class Log implements LogSeverityFunctions {
     async function writeWithResource(resource: {} | null) {
       let decoratedEntries: EntryJson[];
       try {
-        decoratedEntries = self.decorateEntries_(arrify(entry) as Entry[]);
+        decoratedEntries = self.decorateEntries(arrify(entry) as Entry[]);
       } catch (err) {
         // Ignore errors (the API will speak up if it has an issue).
       }
@@ -946,7 +946,7 @@ class Log implements LogSeverityFunctions {
    * @returns {object[]} Serialized entries.
    * @throws if there is an error during serialization.
    */
-  decorateEntries_(entries: Entry[]): EntryJson[] {
+  private decorateEntries(entries: Entry[]): EntryJson[] {
     return entries.map(entry => {
       if (!(entry instanceof Entry)) {
         entry = this.entry(entry);

--- a/src/log.ts
+++ b/src/log.ts
@@ -887,6 +887,7 @@ class Log implements LogSeverityFunctions {
     const options = opts ? (opts as WriteOptions) : {};
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
+    // Autodetect monitored resource if not specified by user in WriteOptions.
     if (options.resource) {
       if (options.resource.labels) snakecaseKeys(options.resource.labels);
       return writeWithResource(options.resource);
@@ -899,6 +900,8 @@ class Log implements LogSeverityFunctions {
       this.logging.detectedResource = resource;
       return writeWithResource(resource);
     }
+    // writeWithResource formats entries and writes them to loggingService API.
+    // Service expects props: logName, resource, labels, partialSuccess, dryRun.
     async function writeWithResource(resource: {} | null) {
       let decoratedEntries: EntryJson[];
       try {
@@ -936,9 +939,11 @@ class Log implements LogSeverityFunctions {
     }
   }
 
-  // TODO proper signature of `private decorateEntries` (sans underscore suffix)
   /**
-   * All entries are passed through here in order to get them serialized.
+   * All entries are passed through here in order be formatted and serialized.
+   * User provided Entry values are formatted per LogEntry specifications.
+   * Read more about the LogEntry format:
+   * https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
    *
    * @private
    *

--- a/src/make-http-request.ts
+++ b/src/make-http-request.ts
@@ -16,7 +16,7 @@
 
 import * as http from 'http';
 
-import {CloudLoggingHttpRequest} from '../../http-request';
+import {CloudLoggingHttpRequest} from './http-request';
 
 export interface ServerRequest extends http.IncomingMessage {
   originalUrl: string;

--- a/src/middleware/express/make-middleware.ts
+++ b/src/middleware/express/make-middleware.ts
@@ -18,7 +18,7 @@ import * as http from 'http';
 import onFinished = require('on-finished');
 import {getOrInjectContext, makeHeaderWrapper} from '../context';
 
-import {makeHttpRequestData, ServerRequest} from './make-http-request';
+import {makeHttpRequestData, ServerRequest} from '../../make-http-request';
 import {CloudLoggingHttpRequest} from '../../http-request';
 
 interface AnnotatedRequestType<LoggerType> extends ServerRequest {

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -15,6 +15,7 @@
 import * as assert from 'assert';
 import {describe, it, before, beforeEach, afterEach} from 'mocha';
 import * as extend from 'extend';
+import * as http from 'http';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
@@ -258,4 +259,33 @@ describe('Entry', () => {
       }
     });
   });
+
+  // TODO: restart things here.
+  // describe('extractTraceSpan', () => {
+  //   beforeEach(() => {});
+  //
+  //   it.only('should extract a trace and span', () => {
+  //     const fakeRequest = {
+  //       headers: {
+  //         'user-agent': 'Mocha/test-case',
+  //       },
+  //       statusCode: 200,
+  //       originalUrl: '/foo/bar',
+  //       method: 'PUSH',
+  //     };
+  //
+  //     const httpRequest = http.request({
+  //       host: '127.0.0.1',
+  //       port: 8080,
+  //       method: 'GET',
+  //     });
+  //     httpRequest.setHeader(
+  //       'X-Cloud-Trace-Context',
+  //       '105445aa7843bc8bf206b120001000/1;o=1'
+  //     );
+  //     entry.metadata = {httpRequest};
+  //     const json = entry.toJSON();
+  //     console.log(json);
+  //   });
+  // });
 });

--- a/test/log.ts
+++ b/test/log.ts
@@ -385,7 +385,7 @@ describe('Log', () => {
       ENTRY = {} as Entry;
       ENTRIES = [ENTRY] as Entry[];
       OPTIONS = {} as WriteOptions;
-      decorateEntriesStub = sinon.stub(log, 'decorateEntries_').returnsArg(0);
+      decorateEntriesStub = sinon.stub(log, 'decorateEntries').returnsArg(0);
       truncateEntriesStub = sinon.stub(log, 'truncateEntries').returnsArg(0);
     });
     afterEach(() => {
@@ -686,7 +686,7 @@ describe('Log', () => {
     });
   });
 
-  describe('decorateEntries_', () => {
+  describe('decorateEntries', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let toJSONResponse: any;
     let logEntryStub: sinon.SinonStub;
@@ -706,7 +706,7 @@ describe('Log', () => {
 
     it('should create an Entry object if one is not provided', () => {
       const entry = {};
-      const decoratedEntries = log.decorateEntries_([entry]);
+      const decoratedEntries = log.decorateEntries([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
       assert(log.entry.calledWithExactly(entry));
     });
@@ -714,7 +714,7 @@ describe('Log', () => {
     it('should get JSON format from Entry object', () => {
       const entry = new Entry();
       entry.toJSON = () => toJSONResponse as {} as EntryJson;
-      const decoratedEntries = log.decorateEntries_([entry]);
+      const decoratedEntries = log.decorateEntries([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
       assert(log.entry.notCalled);
     });
@@ -726,7 +726,7 @@ describe('Log', () => {
         .stub(entry, 'toJSON')
         .returns({} as EntryJson);
 
-      log.decorateEntries_([entry]);
+      log.decorateEntries([entry]);
       assert(localJSONStub.calledWithExactly({removeCircular: true}));
     });
 
@@ -734,7 +734,7 @@ describe('Log', () => {
       const entry = new Entry();
       sinon.stub(entry, 'toJSON').throws('Error.');
       assert.throws(() => {
-        log.decorateEntries_([entry]);
+        log.decorateEntries([entry]);
       }, 'Error.');
     });
   });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -20,7 +20,7 @@ import {ServerResponse} from 'http';
 import {
   makeHttpRequestData,
   ServerRequest,
-} from '../../../src/middleware/express/make-http-request';
+} from '../src/make-http-request';
 
 describe('middleware/express/make-http-request', () => {
   it('should convert latency to proto Duration', () => {


### PR DESCRIPTION
Changes:
1. Users can now log.write(entry.metadata.requestObj), and get back a formatted GCP `HTTPRequest` log per LogEntry guidelines: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest
2. Lifted `make-http-requests` out of /middleware subdirectories. Since it’s not just for middleware. Clean, as http-request was already in the main directory. 

Prerequisite to: #1083
