### PR TITLE
feat: users can log raw http request objects with trace

### DIFF
--- a/samples/test/http-request.test.js
+++ b/samples/test/http-request.test.js
@@ -27,7 +27,7 @@ const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node http-request';
 
 describe('http-request', () => {
-  it.only('should log an entry', () => {
+  it('should log an entry', () => {
     const stdout = execSync(`${cmd} ${projectId} ${logName}`);
     assert.include(stdout, 'Logged: Hello, world!');
   });

--- a/samples/test/http-request.test.js
+++ b/samples/test/http-request.test.js
@@ -27,7 +27,7 @@ const projectId = process.env.GCLOUD_PROJECT;
 const cmd = 'node http-request';
 
 describe('http-request', () => {
-  it('should log an entry', () => {
+  it.only('should log an entry', () => {
     const stdout = execSync(`${cmd} ${projectId} ${logName}`);
     assert.include(stdout, 'Logged: Hello, world!');
   });

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -21,18 +21,16 @@ import {google} from '../protos/protos';
 import {objToStruct, structToObj} from './common';
 import {CloudLoggingHttpRequest} from './http-request';
 import {makeHttpRequestData, ServerRequest} from './make-http-request';
-import * as http from 'http';
 
 const eventId = new EventId();
 
-// Additional field types supported by this client library.
+// Accepted field types from user supported by this client library.
 export type Timestamp = google.protobuf.ITimestamp | Date | string;
 export type LogSeverity = google.logging.type.LogSeverity | string;
 export type HttpRequest =
   | google.logging.type.IHttpRequest
   | CloudLoggingHttpRequest
   | ServerRequest;
-
 export type LogEntry = Omit<
   google.logging.v2.ILogEntry,
   'timestamp' | 'severity' | 'httpRequest'
@@ -45,14 +43,16 @@ export type LogEntry = Omit<
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Data = any;
 
-// The final Entry format submitted to the LoggingService API.
+// Final Entry format submitted to the LoggingService API.
 export interface EntryJson {
   timestamp: Timestamp;
   insertId: number;
   jsonPayload?: google.protobuf.IStruct;
   textPayload?: string;
   httpRequest?: google.protobuf.IStruct;
-  //  TODO: explicitly declare trace/span here as well
+  trace?: string;
+  spanId?: string;
+  traceSampled?: boolean;
 }
 
 export interface ToJsonOptions {
@@ -164,7 +164,11 @@ class Entry {
    *     object with a string value, `[Circular]`.
    */
   toJSON(options: ToJsonOptions = {}) {
-    let entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
+    // Format httpRequest (and trace/span)
+    if (this.metadata?.httpRequest) {
+      this.formatHttpRequest();
+    }
+    const entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
     // Format log message
     if (Object.prototype.toString.call(this.data) === '[object Object]') {
       entry.jsonPayload = objToStruct(this.data, {
@@ -193,9 +197,6 @@ class Entry {
         nanos: nanoSecs ? Number(nanoSecs.padEnd(9, '0')) : 0,
       };
     }
-    if (this.metadata?.httpRequest) {
-      entry = this.formatHttpRequest(entry);
-    }
     return entry;
   }
 
@@ -206,26 +207,18 @@ class Entry {
    * Note: logs from middleware are already formatted. Read more:
    * https://cloud.google.com/trace/docs/setup#force-trace
    *
-   * @param entry
    * @private
    */
-  private formatHttpRequest(entry: EntryJson) {
-    console.log(entry);
-    console.log(typeof this.metadata?.httpRequest);
-    // Goal: return a better formatted EntryJson
-    return entry;
-    // req.headers['x-cloud-trace-context'],
-
-    // if (typeof e.httpRequest == 'CloudLoggingHttpRequest') {
-
-    // }
-    // const req = this.metadata?.httpRequest as http.ClientRequest;
-    // const context = req.getHeader('X-Cloud-Trace-Context');
-    // if (context) {
-    //   //TODO do the parsing here
-    //   entry.trace = context.toString();
-    // }
-    // return entry;
+  private formatHttpRequest() {
+    // Detect & handle if user logged a raw incoming HTTP request
+    const rawReq = this.metadata.httpRequest;
+    if (rawReq && ('statusCode' || 'headers' || 'method' || 'url' in rawReq)) {
+      this.metadata.httpRequest = makeHttpRequestData(rawReq as ServerRequest);
+      console.log('structured: ');
+      console.log(this.metadata.httpRequest);
+      // TODO extract more headers here.
+    }
+    console.log('After:');
   }
 
   /**

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -186,27 +186,28 @@ class Entry {
         nanos: nanoSecs ? Number(nanoSecs.padEnd(9, '0')) : 0,
       };
     }
-    // Format CloudLoggingHttpRequest, extract trace & span from http headers
-    // if available. Note: logs from middleware are already formatted.
+    // Format CloudLoggingHttpRequest
     if (this.metadata?.httpRequest) {
-      entry = this.extractTraceSpan(entry);
+      entry = this.formatHttpRequest(entry);
     }
     return entry;
   }
 
   /**
-   * If users provided X-Cloud-Trace-Context in header, extract trace & span.
-   * Read more: https://cloud.google.com/trace/docs/setup#force-trace
+   * Formats user provided HTTP requests into structured HTTPRequest format.
+   * If users provided X-Cloud-Trace-Context in header, extract trace & span
+   * Note: logs from middleware are already formatted. Read more:
+   * https://cloud.google.com/trace/docs/setup#force-trace
+   *
    * @param entry
    * @private
    */
-  private extractTraceSpan(entry: EntryJson) {
+  private formatHttpRequest(entry: EntryJson) {
     const req = this.metadata?.httpRequest as http.ClientRequest;
     const context = req.getHeader('X-Cloud-Trace-Context');
     if (context) {
       //TODO do the parsing here
       entry.trace = context.toString();
-      console.log(`entry trace is: ${entry.trace}`);
     }
     return entry;
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -164,7 +164,7 @@ class Entry {
    *     object with a string value, `[Circular]`.
    */
   toJSON(options: ToJsonOptions = {}) {
-    let entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
+    let entry = extend(true, {}, this.metadata) as {} as EntryJson;
     // Format log message
     if (Object.prototype.toString.call(this.data) === '[object Object]') {
       entry.jsonPayload = objToStruct(this.data, {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -49,10 +49,6 @@ export interface EntryJson {
   insertId: number;
   jsonPayload?: google.protobuf.IStruct;
   textPayload?: string;
-  httpRequest?: google.protobuf.IStruct;
-  trace?: string;
-  spanId?: string;
-  traceSampled?: boolean;
 }
 
 export interface ToJsonOptions {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -164,10 +164,8 @@ class Entry {
    *     object with a string value, `[Circular]`.
    */
   toJSON(options: ToJsonOptions = {}) {
-    // Format httpRequest (and trace/span)
-    if (this.metadata?.httpRequest) {
-      this.formatHttpRequest();
-    }
+    // Format httpRequest and trace/span if available.
+    if (this.metadata?.httpRequest) this.formatHttpRequest();
     const entry = extend(true, {}, this.metadata) as {} as EntryJson;
     // Format log message
     if (Object.prototype.toString.call(this.data) === '[object Object]') {
@@ -228,14 +226,13 @@ class Entry {
         'x-cloud-trace-context'
       ];
       if (context) {
-        const regex = /([a-f\d]+)?(\/?([a-f\d]+))?(;?o=(\d))/;
+        const regex = /([a-f\d]+)?(\/?([a-f\d]+))?(;?o=(\d))?/;
         const match = context.toString().match(regex);
         if (match) {
-          if (!this.metadata.trace && match.length > 1)
-            this.metadata.trace = match[1];
-          if (!this.metadata.spanId && match.length > 3)
+          if (!this.metadata.trace && match[1]) this.metadata.trace = match[1];
+          if (!this.metadata.spanId && match[3])
             this.metadata.spanId = match[3];
-          if (this.metadata.traceSampled === undefined && match.length > 5)
+          if (this.metadata.traceSampled === undefined && match[5])
             this.metadata.traceSampled = match[5] === '1';
         }
       }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -164,7 +164,7 @@ class Entry {
     if (this.metadata?.httpRequest) {
       this.formatHttpRequest();
     }
-    const entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
+    const entry = extend(true, {}, this.metadata) as {} as EntryJson;
     // Format log message
     if (Object.prototype.toString.call(this.data) === '[object Object]') {
       entry.jsonPayload = objToStruct(this.data, {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -157,7 +157,7 @@ class Entry {
    *     object with a string value, `[Circular]`.
    */
   toJSON(options: ToJsonOptions = {}) {
-    let entry = (extend(true, {}, this.metadata) as {}) as EntryJson;
+    let entry = extend(true, {}, this.metadata) as {} as EntryJson;
     // Format log message
     if (Object.prototype.toString.call(this.data) === '[object Object]') {
       entry.jsonPayload = objToStruct(this.data, {

--- a/src/log.ts
+++ b/src/log.ts
@@ -431,7 +431,7 @@ class Log implements LogSeverityFunctions {
   entry(metadataOrData?: LogEntry | string | {}, data?: string | {}) {
     let metadata: LogEntry;
     if (!data && metadataOrData?.hasOwnProperty('httpRequest')) {
-      // If user logs entry(httpRequest)
+      // If user logs entry(metadata.httpRequest)
       metadata = metadataOrData as LogEntry;
       data = {};
     } else if (!data) {

--- a/src/log.ts
+++ b/src/log.ts
@@ -902,7 +902,7 @@ class Log implements LogSeverityFunctions {
     async function writeWithResource(resource: {} | null) {
       let decoratedEntries: EntryJson[];
       try {
-        decoratedEntries = self.decorateEntries_(arrify(entry) as Entry[]);
+        decoratedEntries = self.decorateEntries(arrify(entry) as Entry[]);
       } catch (err) {
         // Ignore errors (the API will speak up if it has an issue).
       }
@@ -946,7 +946,7 @@ class Log implements LogSeverityFunctions {
    * @returns {object[]} Serialized entries.
    * @throws if there is an error during serialization.
    */
-  decorateEntries_(entries: Entry[]): EntryJson[] {
+  private decorateEntries(entries: Entry[]): EntryJson[] {
     return entries.map(entry => {
       if (!(entry instanceof Entry)) {
         entry = this.entry(entry);

--- a/src/log.ts
+++ b/src/log.ts
@@ -887,6 +887,7 @@ class Log implements LogSeverityFunctions {
     const options = opts ? (opts as WriteOptions) : {};
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
+    // Autodetect monitored resource if not specified by user in WriteOptions.
     if (options.resource) {
       if (options.resource.labels) snakecaseKeys(options.resource.labels);
       return writeWithResource(options.resource);
@@ -899,6 +900,8 @@ class Log implements LogSeverityFunctions {
       this.logging.detectedResource = resource;
       return writeWithResource(resource);
     }
+    // writeWithResource formats entries and writes them to loggingService API.
+    // Service expects props: logName, resource, labels, partialSuccess, dryRun.
     async function writeWithResource(resource: {} | null) {
       let decoratedEntries: EntryJson[];
       try {
@@ -936,9 +939,11 @@ class Log implements LogSeverityFunctions {
     }
   }
 
-  // TODO proper signature of `private decorateEntries` (sans underscore suffix)
   /**
-   * All entries are passed through here in order to get them serialized.
+   * All entries are passed through here in order be formatted and serialized.
+   * User provided Entry values are formatted per LogEntry specifications.
+   * Read more about the LogEntry format:
+   * https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
    *
    * @private
    *

--- a/src/make-http-request.ts
+++ b/src/make-http-request.ts
@@ -16,7 +16,7 @@
 
 import * as http from 'http';
 
-import {CloudLoggingHttpRequest} from '../../http-request';
+import {CloudLoggingHttpRequest} from './http-request';
 
 export interface ServerRequest extends http.IncomingMessage {
   originalUrl: string;

--- a/src/make-http-request.ts
+++ b/src/make-http-request.ts
@@ -18,9 +18,10 @@ import * as http from 'http';
 
 import {CloudLoggingHttpRequest} from './http-request';
 
-export interface ServerRequest
-  extends CloudLoggingHttpRequest,
-    http.IncomingMessage {
+/**
+ * Abstraction of http.IncomingMessage used by middleware implementation.
+ */
+export interface ServerRequest extends http.IncomingMessage {
   originalUrl: string;
 }
 
@@ -34,7 +35,7 @@ export interface ServerRequest
  * @param latencyMilliseconds
  */
 export function makeHttpRequestData(
-  req: ServerRequest,
+  req: ServerRequest | http.IncomingMessage,
   res?: http.ServerResponse,
   latencyMilliseconds?: number
 ): CloudLoggingHttpRequest {
@@ -52,8 +53,8 @@ export function makeHttpRequestData(
     const url = new URL(requestUrl);
     protocol = url.protocol;
   }
-  // OriginalURL overwrites request.url
-  if (req.originalUrl) {
+  // OriginalURL overwrites inferred url
+  if ('originalUrl' in req && req.originalUrl) {
     requestUrl = req.originalUrl;
     const url = new URL(requestUrl);
     protocol = url.protocol;

--- a/src/make-http-request.ts
+++ b/src/make-http-request.ts
@@ -64,9 +64,8 @@ export function makeHttpRequestData(
   }
   if (res) {
     res.statusCode ? (status = res.statusCode) : null;
-    res.hasHeader('Content-Length')
-      ? (responseSize = Number(res.getHeader('Content-Length')))
-      : null;
+    responseSize =
+      (res.getHeader && Number(res.getHeader('Content-Length'))) || 0;
   }
   if (latencyMilliseconds) {
     latency = {

--- a/src/make-http-request.ts
+++ b/src/make-http-request.ts
@@ -46,6 +46,7 @@ export function makeHttpRequestData(
     status,
     responseSize,
     latency;
+  // Format request properties
   if (req.url) {
     requestUrl = req.url;
     const url = new URL(requestUrl);
@@ -62,18 +63,19 @@ export function makeHttpRequestData(
     req.headers['user-agent'] ? (userAgent = req.headers['user-agent']) : null;
     req.headers['referer'] ? (referer = req.headers['referer']) : null;
   }
+  // Format response properties
   if (res) {
     res.statusCode ? (status = res.statusCode) : null;
     responseSize =
       (res.getHeader && Number(res.getHeader('Content-Length'))) || 0;
   }
+  // Format latency
   if (latencyMilliseconds) {
     latency = {
       seconds: Math.floor(latencyMilliseconds / 1e3),
       nanos: Math.floor((latencyMilliseconds % 1e3) * 1e6),
     };
   }
-
   // Only include the property if its value exists
   return Object.assign(
     {},

--- a/src/middleware/express/make-middleware.ts
+++ b/src/middleware/express/make-middleware.ts
@@ -18,7 +18,7 @@ import * as http from 'http';
 import onFinished = require('on-finished');
 import {getOrInjectContext, makeHeaderWrapper} from '../context';
 
-import {makeHttpRequestData, ServerRequest} from './make-http-request';
+import {makeHttpRequestData, ServerRequest} from '../../make-http-request';
 import {CloudLoggingHttpRequest} from '../../http-request';
 
 interface AnnotatedRequestType<LoggerType> extends ServerRequest {

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -27,6 +27,7 @@ import {after, before} from 'mocha';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const http2spy = require('http2spy');
 import {Logging, Sink, Log, Entry, TailEntriesResponse} from '../src';
+import {CloudLoggingHttpRequest} from '../src/http-request';
 
 // block all attempts to chat with the metadata server (kokoro runs on GCE)
 nock(HOST_ADDRESS)

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -641,6 +641,8 @@ describe('Logging', () => {
       });
     });
 
+    // TODO: maybe add an e2e test here.
+
     it('should set the default resource', done => {
       const {log} = getTestLog();
 

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -15,7 +15,6 @@
 import * as assert from 'assert';
 import {describe, it, before, beforeEach, afterEach} from 'mocha';
 import * as extend from 'extend';
-import * as http from 'http';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
@@ -259,33 +258,4 @@ describe('Entry', () => {
       }
     });
   });
-
-  // TODO: restart things here.
-  // describe('extractTraceSpan', () => {
-  //   beforeEach(() => {});
-  //
-  //   it.only('should extract a trace and span', () => {
-  //     const fakeRequest = {
-  //       headers: {
-  //         'user-agent': 'Mocha/test-case',
-  //       },
-  //       statusCode: 200,
-  //       originalUrl: '/foo/bar',
-  //       method: 'PUSH',
-  //     };
-  //
-  //     const httpRequest = http.request({
-  //       host: '127.0.0.1',
-  //       port: 8080,
-  //       method: 'GET',
-  //     });
-  //     httpRequest.setHeader(
-  //       'X-Cloud-Trace-Context',
-  //       '105445aa7843bc8bf206b120001000/1;o=1'
-  //     );
-  //     entry.metadata = {httpRequest};
-  //     const json = entry.toJSON();
-  //     console.log(json);
-  //   });
-  // });
 });

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -18,9 +18,7 @@ import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
-import {ServerRequest} from '../src/make-http-request';
 import * as http from 'http';
-import * as nock from 'nock';
 
 let fakeEventIdNewOverride: Function | null;
 
@@ -40,7 +38,6 @@ const objToStruct = (obj: {}, opts: {}) => {
 const structToObj = (struct: {}) => {
   return (fakeStructToObj || common.structToObj)(struct);
 };
-const FAKE_URL = 'http://google.com';
 
 describe('Entry', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -265,7 +262,7 @@ describe('Entry', () => {
     it('should convert a raw incoming HTTP request', () => {
       const req = {
         method: 'GET',
-      } as ServerRequest;
+      } as http.IncomingMessage;
       req.headers = {};
       entry.metadata.httpRequest = req;
       const json = entry.toJSON();
@@ -331,7 +328,7 @@ describe('Entry', () => {
       for (const test of tests) {
         const req = {
           method: 'GET',
-        } as unknown as ServerRequest;
+        } as unknown as http.IncomingMessage;
         // Mock raw http headers with lowercased keys.
         req.headers = {
           'x-cloud-trace-context': test.header,
@@ -350,7 +347,7 @@ describe('Entry', () => {
     it('should not overwrite user defined trace and span', () => {
       const req = {
         method: 'GET',
-      } as unknown as ServerRequest;
+      } as unknown as http.IncomingMessage;
       // Mock raw http headers with lowercased keys.
       req.headers = {
         'x-cloud-trace-context': '105445aa7843bc8bf206b120001000/000000001;o=1',

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -15,6 +15,7 @@
 import * as assert from 'assert';
 import {describe, it, before, beforeEach, afterEach} from 'mocha';
 import * as extend from 'extend';
+import * as http from 'http';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
@@ -258,4 +259,33 @@ describe('Entry', () => {
       }
     });
   });
+
+  // TODO: restart things here.
+  // describe('extractTraceSpan', () => {
+  //   beforeEach(() => {});
+  //
+  //   it.only('should extract a trace and span', () => {
+  //     const fakeRequest = {
+  //       headers: {
+  //         'user-agent': 'Mocha/test-case',
+  //       },
+  //       statusCode: 200,
+  //       originalUrl: '/foo/bar',
+  //       method: 'PUSH',
+  //     };
+  //
+  //     const httpRequest = http.request({
+  //       host: '127.0.0.1',
+  //       port: 8080,
+  //       method: 'GET',
+  //     });
+  //     httpRequest.setHeader(
+  //       'X-Cloud-Trace-Context',
+  //       '105445aa7843bc8bf206b120001000/1;o=1'
+  //     );
+  //     entry.metadata = {httpRequest};
+  //     const json = entry.toJSON();
+  //     console.log(json);
+  //   });
+  // });
 });

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -18,8 +18,7 @@ import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
-import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
-import {ServerResponse} from 'http';
+import {ServerRequest} from '../src/make-http-request';
 
 let fakeEventIdNewOverride: Function | null;
 
@@ -261,16 +260,18 @@ describe('Entry', () => {
     });
 
     //  TODO: it should format HTTPRequest from CloudLoggingHttpRequest form
-    it.only('should format HTTPRequest from ServerRequest', () => {
-      entry.metadata.httpRequest = {
-        method: 'GET',
-        statusCode: 200,
-        headers: {},
-      } as ServerRequest;
-      const json = entry.toJSON();
-      assert.deepStrictEqual(json.httpRequest, {
-        method: 'GET',
-      });
+    it('should convert a raw incoming HTTP request', () => {
+      // entry.metadata.httpRequest = {
+      //   method: 'GET',
+      //   url: 'http://google.com/',
+      // } as ServerRequest;
+      // const json = entry.toJSON();
+      //
+      // assert.strictEqual(json.httprequest, {
+      //   protocol: 'http:';
+      //   requestUrl: 'http://google.com/',
+      //   requestMethod: 'GET',
+      // });
     });
     //  TODO: it should lift span & trace from x-cloud-context-trace
   });

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -18,6 +18,8 @@ import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 import * as entryTypes from '../src/entry';
 import * as common from '../src/common';
+import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
+import {ServerResponse} from 'http';
 
 let fakeEventIdNewOverride: Function | null;
 
@@ -257,5 +259,19 @@ describe('Entry', () => {
         });
       }
     });
+
+    //  TODO: it should format HTTPRequest from CloudLoggingHttpRequest form
+    it.only('should format HTTPRequest from ServerRequest', () => {
+      entry.metadata.httpRequest = {
+        method: 'GET',
+        statusCode: 200,
+        headers: {},
+      } as ServerRequest;
+      const json = entry.toJSON();
+      assert.deepStrictEqual(json.httpRequest, {
+        method: 'GET',
+      });
+    });
+    //  TODO: it should lift span & trace from x-cloud-context-trace
   });
 });

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -329,9 +329,9 @@ describe('Entry', () => {
         },
       ];
       for (const test of tests) {
-        const req = ({
+        const req = {
           method: 'GET',
-        } as unknown) as ServerRequest;
+        } as unknown as ServerRequest;
         // Mock raw http headers with lowercased keys.
         req.headers = {
           'x-cloud-trace-context': test.header,
@@ -348,9 +348,9 @@ describe('Entry', () => {
     });
 
     it('should not overwrite user defined trace and span', () => {
-      const req = ({
+      const req = {
         method: 'GET',
-      } as unknown) as ServerRequest;
+      } as unknown as ServerRequest;
       // Mock raw http headers with lowercased keys.
       req.headers = {
         'x-cloud-trace-context': '105445aa7843bc8bf206b120001000/000000001;o=1',

--- a/test/log.ts
+++ b/test/log.ts
@@ -385,7 +385,7 @@ describe('Log', () => {
       ENTRY = {} as Entry;
       ENTRIES = [ENTRY] as Entry[];
       OPTIONS = {} as WriteOptions;
-      decorateEntriesStub = sinon.stub(log, 'decorateEntries_').returnsArg(0);
+      decorateEntriesStub = sinon.stub(log, 'decorateEntries').returnsArg(0);
       truncateEntriesStub = sinon.stub(log, 'truncateEntries').returnsArg(0);
     });
     afterEach(() => {
@@ -686,7 +686,7 @@ describe('Log', () => {
     });
   });
 
-  describe('decorateEntries_', () => {
+  describe('decorateEntries', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let toJSONResponse: any;
     let logEntryStub: sinon.SinonStub;
@@ -706,7 +706,7 @@ describe('Log', () => {
 
     it('should create an Entry object if one is not provided', () => {
       const entry = {};
-      const decoratedEntries = log.decorateEntries_([entry]);
+      const decoratedEntries = log.decorateEntries([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
       assert(log.entry.calledWithExactly(entry));
     });
@@ -714,7 +714,7 @@ describe('Log', () => {
     it('should get JSON format from Entry object', () => {
       const entry = new Entry();
       entry.toJSON = () => toJSONResponse as {} as EntryJson;
-      const decoratedEntries = log.decorateEntries_([entry]);
+      const decoratedEntries = log.decorateEntries([entry]);
       assert.strictEqual(decoratedEntries[0], toJSONResponse);
       assert(log.entry.notCalled);
     });
@@ -726,7 +726,7 @@ describe('Log', () => {
         .stub(entry, 'toJSON')
         .returns({} as EntryJson);
 
-      log.decorateEntries_([entry]);
+      log.decorateEntries([entry]);
       assert(localJSONStub.calledWithExactly({removeCircular: true}));
     });
 
@@ -734,7 +734,7 @@ describe('Log', () => {
       const entry = new Entry();
       sinon.stub(entry, 'toJSON').throws('Error.');
       assert.throws(() => {
-        log.decorateEntries_([entry]);
+        log.decorateEntries([entry]);
       }, 'Error.');
     });
   });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -26,7 +26,7 @@ describe('make-http-request', () => {
       url: 'http://wrongemail.com/',
       originalUrl: 'http://google.com/',
     } as ServerRequest;
-    const cloudReq = makeHttpRequestData(req)
+    const cloudReq = makeHttpRequestData(req);
     assert.strictEqual(cloudReq.protocol, 'http:');
     assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
     assert.strictEqual(cloudReq.requestMethod, 'GET');

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -17,10 +17,7 @@
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {ServerResponse} from 'http';
-import {
-  makeHttpRequestData,
-  ServerRequest,
-} from '../src/make-http-request';
+import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
 
 describe('middleware/express/make-http-request', () => {
   it('should convert latency to proto Duration', () => {

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -50,17 +50,6 @@ describe('make-http-request', () => {
     assert.strictEqual(cloudReq.status, undefined);
   });
 
-  it('should infer as many request values as possible', () => {
-    const req = {
-      method: 'GET',
-      url: 'http://google.com/',
-    } as ServerRequest;
-    const cloudReq = makeHttpRequestData(req)
-    assert.strictEqual(cloudReq.protocol, 'http:');
-    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
-    assert.strictEqual(cloudReq.requestMethod, 'GET');
-  });
-
   it('should convert latency to proto Duration', () => {
     const fakeRequest = {headers: {}};
     const fakeResponse = {};

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -60,7 +60,7 @@ describe('make-http-request', () => {
         'Content-Length': RESPONSE_SIZE,
       },
     } as unknown as http.ServerResponse;
-    res.getHeader = function (str: string) {
+    res.getHeader = function () {
       return 2048;
     };
     const cloudReq = makeHttpRequestData(req, res);

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -41,7 +41,7 @@ describe('make-http-request', () => {
         'user-agent': 'some-agent',
         referer: 'some-referer',
       },
-    } as ServerRequest;
+    } as http.IncomingMessage;
     const cloudReq = makeHttpRequestData(req);
     assert.strictEqual(cloudReq.protocol, 'http:');
     assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -20,7 +20,7 @@ import {ServerResponse} from 'http';
 import {
   makeHttpRequestData,
   ServerRequest,
-} from '../../../src/middleware/express/make-http-request';
+} from '../src/make-http-request';
 
 describe('middleware/express/make-http-request', () => {
   it('should convert latency to proto Duration', () => {

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -18,6 +18,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {ServerResponse} from 'http';
 import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
+import * as http from 'http';
 
 describe('make-http-request', () => {
   it('should prioritize originalUrl if provided', () => {
@@ -50,23 +51,22 @@ describe('make-http-request', () => {
     assert.strictEqual(cloudReq.status, undefined);
   });
 
-  //TODO : do this
   it('should infer as many response values as possible', () => {
-    const req = {
-      method: 'GET',
-      url: 'http://google.com/',
+    const RESPONSE_SIZE = 2048;
+    const req = {} as ServerRequest;
+    const res = ({
+      statusCode: 200,
       headers: {
-        'user-agent': 'some-agent',
-        referer: 'some-referer',
+        'Content-Length': RESPONSE_SIZE,
       },
-    } as ServerRequest;
-    const cloudReq = makeHttpRequestData(req);
-    assert.strictEqual(cloudReq.protocol, 'http:');
-    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
-    assert.strictEqual(cloudReq.requestMethod, 'GET');
-    assert.strictEqual(cloudReq.userAgent, 'some-agent');
-    assert.strictEqual(cloudReq.referer, 'some-referer');
-    assert.strictEqual(cloudReq.status, undefined);
+    } as unknown) as http.ServerResponse;
+    res.getHeader = function (str: string) {
+      return 2048;
+    };
+    const cloudReq = makeHttpRequestData(req, res);
+    console.log(cloudReq);
+    assert.strictEqual(cloudReq.status, 200);
+    assert.strictEqual(cloudReq.responseSize, RESPONSE_SIZE);
   });
 
   it('should convert latency to proto Duration', () => {

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -19,7 +19,7 @@ import {describe, it} from 'mocha';
 import {ServerResponse} from 'http';
 import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
 
-describe('middleware/express/make-http-request', () => {
+describe('make-http-request', () => {
   it('should convert latency to proto Duration', () => {
     const fakeRequest = {headers: {}};
     const fakeResponse = {};
@@ -45,5 +45,8 @@ describe('middleware/express/make-http-request', () => {
       1.0000000001
     );
     assert.deepStrictEqual(h3.latency, {seconds: 0, nanos: 1e6});
+  });
+  // TODO
+  it('should infer status and response size', () => {
   });
 });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -20,6 +20,47 @@ import {ServerResponse} from 'http';
 import {makeHttpRequestData, ServerRequest} from '../src/make-http-request';
 
 describe('make-http-request', () => {
+  it('should prioritize originalUrl if provided', () => {
+    const req = {
+      method: 'GET',
+      url: 'http://wrongemail.com/',
+      originalUrl: 'http://google.com/',
+    } as ServerRequest;
+    const cloudReq = makeHttpRequestData(req)
+    assert.strictEqual(cloudReq.protocol, 'http:');
+    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
+    assert.strictEqual(cloudReq.requestMethod, 'GET');
+  });
+
+  it('should infer as many request values as possible', () => {
+    const req = {
+      method: 'GET',
+      url: 'http://google.com/',
+      headers: {
+        'user-agent': 'some-agent',
+        referer: 'some-referer',
+      },
+    } as ServerRequest;
+    const cloudReq = makeHttpRequestData(req);
+    assert.strictEqual(cloudReq.protocol, 'http:');
+    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
+    assert.strictEqual(cloudReq.requestMethod, 'GET');
+    assert.strictEqual(cloudReq.userAgent, 'some-agent');
+    assert.strictEqual(cloudReq.referer, 'some-referer');
+    assert.strictEqual(cloudReq.status, undefined);
+  });
+
+  it('should infer as many request values as possible', () => {
+    const req = {
+      method: 'GET',
+      url: 'http://google.com/',
+    } as ServerRequest;
+    const cloudReq = makeHttpRequestData(req)
+    assert.strictEqual(cloudReq.protocol, 'http:');
+    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
+    assert.strictEqual(cloudReq.requestMethod, 'GET');
+  });
+
   it('should convert latency to proto Duration', () => {
     const fakeRequest = {headers: {}};
     const fakeResponse = {};
@@ -45,8 +86,5 @@ describe('make-http-request', () => {
       1.0000000001
     );
     assert.deepStrictEqual(h3.latency, {seconds: 0, nanos: 1e6});
-  });
-  // TODO
-  it('should infer status and response size', () => {
   });
 });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -64,7 +64,6 @@ describe('make-http-request', () => {
       return 2048;
     };
     const cloudReq = makeHttpRequestData(req, res);
-    console.log(cloudReq);
     assert.strictEqual(cloudReq.status, 200);
     assert.strictEqual(cloudReq.responseSize, RESPONSE_SIZE);
   });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -54,12 +54,12 @@ describe('make-http-request', () => {
   it('should infer as many response values as possible', () => {
     const RESPONSE_SIZE = 2048;
     const req = {} as ServerRequest;
-    const res = ({
+    const res = {
       statusCode: 200,
       headers: {
         'Content-Length': RESPONSE_SIZE,
       },
-    } as unknown) as http.ServerResponse;
+    } as unknown as http.ServerResponse;
     res.getHeader = function (str: string) {
       return 2048;
     };

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -47,6 +47,5 @@ describe('make-http-request', () => {
     assert.deepStrictEqual(h3.latency, {seconds: 0, nanos: 1e6});
   });
   // TODO
-  it('should infer status and response size', () => {
-  });
+  it('should infer status and response size', () => {});
 });

--- a/test/test-make-http-request.ts
+++ b/test/test-make-http-request.ts
@@ -50,6 +50,25 @@ describe('make-http-request', () => {
     assert.strictEqual(cloudReq.status, undefined);
   });
 
+  //TODO : do this
+  it('should infer as many response values as possible', () => {
+    const req = {
+      method: 'GET',
+      url: 'http://google.com/',
+      headers: {
+        'user-agent': 'some-agent',
+        referer: 'some-referer',
+      },
+    } as ServerRequest;
+    const cloudReq = makeHttpRequestData(req);
+    assert.strictEqual(cloudReq.protocol, 'http:');
+    assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
+    assert.strictEqual(cloudReq.requestMethod, 'GET');
+    assert.strictEqual(cloudReq.userAgent, 'some-agent');
+    assert.strictEqual(cloudReq.referer, 'some-referer');
+    assert.strictEqual(cloudReq.status, undefined);
+  });
+
   it('should convert latency to proto Duration', () => {
     const fakeRequest = {headers: {}};
     const fakeResponse = {};


### PR DESCRIPTION
A. **Users can log raw http.incomingmessage (requests) now:**
1. Users can now log.write(entry.metadata.requestObj) where reqObj is a **raw incoming HTTP request** type. 
2. Users can now log.write(entry.metadata.requestObj) where reqObj is an **exported CloudLoggingHttpRequest** type.
3. The above mentioned request logs are auto-formatted into GCP compliant structured request logs. See LogEntry guidelines: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest
3. Lifted `make-http-requests` out of /middleware subdirectories. Since it’s not just for middleware. This is cleaner, as http-request was already in the main directory. 

B. **Users can force tracing by providing x-cloud-trace-context in http headers (in various formats):**
See: https://cloud.google.com/trace/docs/setup#force-trace 
1.  `trace`, `spanID` and `traceSampled` fields in X-Cloud-Trace-Context can be optional (see context/trace_context.proto)
2. TraceSample should default to false (verified with nwang@)
3. Trace/span IDs should still be included in log contexts even when traceSampled is false, because "A non-sampled trace value is still useful as a request correlation identifier." ([LogEntry spec](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry))

Fixes: #1083
