### PR TITLE
fix: allow unformatted originalURL input

### DIFF
--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -70,16 +70,17 @@ export function makeHttpRequestData(
     responseSize,
     latency;
   // Format request properties
-  if (req.url) {
-    requestUrl = req.url;
-    const url = new URL(requestUrl);
-    protocol = url.protocol;
-  }
+  if (req.url) requestUrl = req.url;
   // OriginalURL overwrites inferred url
-  if ('originalUrl' in req && req.originalUrl) {
-    requestUrl = req.originalUrl;
-    const url = new URL(requestUrl);
-    protocol = url.protocol;
+  if ('originalUrl' in req && req.originalUrl) requestUrl = req.originalUrl;
+  // Format protocol from valid URL
+  if (requestUrl) {
+    try {
+      const url = new URL(requestUrl);
+      protocol = url.protocol;
+    } catch (e) {
+      // Library should not panic
+    }
   }
   req.method ? (requestMethod = req.method) : null;
   if (req.headers && req.headers['user-agent']) {

--- a/test/http-request.ts
+++ b/test/http-request.ts
@@ -33,6 +33,16 @@ describe('http-request', () => {
       assert.strictEqual(cloudReq.requestUrl, 'http://google.com/');
       assert.strictEqual(cloudReq.requestMethod, 'GET');
     });
+    it('should not panic on invalid URL', () => {
+      const req = {
+        method: 'GET',
+        originalUrl: 'invalid/url/',
+      } as ServerRequest;
+      const cloudReq = makeHttpRequestData(req);
+      assert.strictEqual(cloudReq.protocol, undefined);
+      assert.strictEqual(cloudReq.requestUrl, 'invalid/url/');
+      assert.strictEqual(cloudReq.requestMethod, 'GET');
+    });
     it('should infer as many request values as possible', () => {
       const req = {
         method: 'GET',


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-logging-winston/issues/607

Allows users to input invalid or badly formatted `originalUrl` values. As it did previously.