### PR TITLE
fix: missing "uuid" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "google-gax": "^2.17.1",
     "on-finished": "^2.3.0",
     "pumpify": "^2.0.1",
-    "stream-events": "^1.0.5"
+    "stream-events": "^1.0.5",
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.0.0",
@@ -89,7 +90,6 @@
     "sinon": "^11.0.0",
     "ts-loader": "^9.0.0",
     "typescript": "^3.8.3",
-    "uuid": "^8.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0",
     "uglify-js": "^3.13.5"


### PR DESCRIPTION
Fixes missing `uuid` dependency used in: https://github.com/googleapis/nodejs-logging/blob/5a0663aafd25d7b09307d94e1efe99118d71e528/src/utils/context.ts#L30-L32
