### PR TITLE
fix: log a warning instead of failing test

### DIFF
--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -118,7 +118,14 @@ describe('Logging', () => {
             }
             return getDateFromGeneratedName(name) < oneHourAgo;
           })
-          .map(o => o.delete())
+          .map(o => {
+            const name = o.name || o.id;
+            try {
+              o.delete();
+            } catch (err) {
+              console.warn(`failed to delete "${name}": ${err}`);
+            }
+          })
       );
     }
   });


### PR DESCRIPTION
Handle flaky tests that fail due deleting non-existing objects.

Fixes #1151
