### PR TITLE
fix: Cannot read property 'forEach' of undefined

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -867,13 +867,12 @@ class Log implements LogSeverityFunctions {
     opts?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     const options = opts ? (opts as WriteOptions) : {};
-    let decoratedEntries: EntryJson[];
     // Extract projectId & resource from Logging - inject & memoize if not.
     await this.logging.setProjectId();
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     const resource = await this.getOrSetResource(options);
     // Extract & format additional context from individual entries.
-    decoratedEntries = this.decorateEntries(arrify(entry) as Entry[]);
+    const decoratedEntries = this.decorateEntries(arrify(entry) as Entry[]);
     this.truncateEntries(decoratedEntries);
     // Clobber `labels` and `resource` fields with WriteOptions from the user.
     const reqOpts = extend(

--- a/src/log.ts
+++ b/src/log.ts
@@ -873,17 +873,13 @@ class Log implements LogSeverityFunctions {
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     const resource = await this.getOrSetResource(options);
     // Extract & format additional context from individual entries.
-    try {
-      decoratedEntries = this.decorateEntries(arrify(entry) as Entry[]);
-    } catch (err) {
-      // Ignore errors (the API will speak up if it has an issue).
-    }
-    this.truncateEntries(decoratedEntries!);
+    decoratedEntries = this.decorateEntries(arrify(entry) as Entry[]);
+    this.truncateEntries(decoratedEntries);
     // Clobber `labels` and `resource` fields with WriteOptions from the user.
     const reqOpts = extend(
       {
         logName: this.formattedName_,
-        entries: decoratedEntries!,
+        entries: decoratedEntries,
         resource,
       },
       options


### PR DESCRIPTION
Remove the try/catch which ignores error when `decoratedEntries` cannot be converted and remain `undefined`, thus failing on later stage since `forEach` cannot be used with `undefined`. This will make sure that real error will be revealed and hence can be addressed.

Fixes [#1113](https://github.com/googleapis/nodejs-logging/issues/1113) 🦕
