### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,12 +296,6 @@ class Logging {
     this.loggingService = new v2.LoggingServiceV2Client(this.options);
   }
 
-  createSink(name: string, config: CreateSinkRequest): Promise<[Sink, LogSink]>;
-  createSink(
-    name: string,
-    config: CreateSinkRequest,
-    callback: CreateSinkCallback
-  ): void;
   /**
    * Config to set for the sink. Not all available options are listed here, see
    * the [Sink
@@ -332,6 +326,12 @@ class Logging {
    * @param {Sink} sink The new {@link Sink}.
    * @param {object} apiResponse The full API response.
    */
+  createSink(name: string, config: CreateSinkRequest): Promise<[Sink, LogSink]>;
+  createSink(
+    name: string,
+    config: CreateSinkRequest,
+    callback: CreateSinkCallback
+  ): void;
   // jscs:disable maximumLineLength
   /**
    * Create a sink.
@@ -474,9 +474,6 @@ class Logging {
     return new Entry(resource, data);
   }
 
-  getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
-  getEntries(callback: GetEntriesCallback): void;
-  getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   /**
    * Query object for listing entries.
    *
@@ -563,6 +560,9 @@ class Logging {
    * region_tag:logging_list_log_entries_advanced
    * Another example:
    */
+  getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
+  getEntries(callback: GetEntriesCallback): void;
+  getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   async getEntries(
     opts?: GetEntriesRequest | GetEntriesCallback
   ): Promise<GetEntriesResponse> {
@@ -842,9 +842,6 @@ class Logging {
     return userStream;
   }
 
-  getLogs(options?: GetLogsRequest): Promise<GetLogsResponse>;
-  getLogs(callback: GetLogsCallback): void;
-  getLogs(options: GetLogsRequest, callback: GetLogsCallback): void;
   /**
    * Query object for listing entries.
    *
@@ -917,6 +914,9 @@ class Logging {
    * region_tag:logging_list_logs
    * Another example:
    */
+  getLogs(options?: GetLogsRequest): Promise<GetLogsResponse>;
+  getLogs(callback: GetLogsCallback): void;
+  getLogs(options: GetLogsRequest, callback: GetLogsCallback): void;
   async getLogs(
     opts?: GetLogsRequest | GetLogsCallback
   ): Promise<GetLogsResponse> {
@@ -1032,9 +1032,6 @@ class Logging {
     return userStream;
   }
 
-  getSinks(options?: GetSinksRequest): Promise<GetSinksResponse>;
-  getSinks(callback: GetSinksCallback): void;
-  getSinks(options: GetSinksRequest, callback: GetSinksCallback): void;
   /**
    * Query object for listing sinks.
    *
@@ -1091,6 +1088,9 @@ class Logging {
    * region_tag:logging_list_sinks
    * Another example:
    */
+  getSinks(options?: GetSinksRequest): Promise<GetSinksResponse>;
+  getSinks(callback: GetSinksCallback): void;
+  getSinks(options: GetSinksRequest, callback: GetSinksCallback): void;
   async getSinks(
     opts?: GetSinksRequest | GetSinksCallback
   ): Promise<GetSinksResponse> {

--- a/src/log-sync.ts
+++ b/src/log-sync.ts
@@ -188,9 +188,6 @@ class LogSync implements LogSeverityFunctions {
   }
 
   // TODO(future): dedupe entry code across LogSync & Log classes.
-  entry(metadata?: LogEntry): Entry;
-  entry(data?: string | {}): Entry;
-  entry(metadata?: LogEntry, data?: string | {}): Entry;
   /**
    * Create an entry object for this log.
    *
@@ -226,6 +223,9 @@ class LogSync implements LogSeverityFunctions {
    * });
    * ```
    */
+  entry(metadata?: LogEntry): Entry;
+  entry(data?: string | {}): Entry;
+  entry(metadata?: LogEntry, data?: string | {}): Entry;
   entry(metadataOrData?: LogEntry | string | {}, data?: string | {}) {
     let metadata: LogEntry;
     if (!data && metadataOrData?.hasOwnProperty('httpRequest')) {

--- a/src/log.ts
+++ b/src/log.ts
@@ -114,13 +114,6 @@ class Log implements LogSeverityFunctions {
     this.name = this.formattedName_.split('/').pop()!;
   }
 
-  alert(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  alert(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  alert(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "ALERT".
    *
@@ -151,6 +144,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  alert(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  alert(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  alert(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   alert(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -161,16 +161,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  critical(
-    entry: Entry | Entry[],
-    options?: WriteOptions
-  ): Promise<ApiResponse>;
-  critical(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  critical(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "CRITICAL".
    *
@@ -203,6 +193,16 @@ class Log implements LogSeverityFunctions {
    */
   critical(
     entry: Entry | Entry[],
+    options?: WriteOptions
+  ): Promise<ApiResponse>;
+  critical(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  critical(entry: Entry | Entry[], callback: ApiResponseCallback): void;
+  critical(
+    entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
@@ -211,13 +211,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  debug(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  debug(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  debug(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "DEBUG".
    *
@@ -248,6 +241,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  debug(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  debug(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  debug(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   debug(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -258,9 +258,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  delete(gaxOptions?: CallOptions): Promise<ApiResponse>;
-  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
-  delete(callback: DeleteCallback): void;
   /**
    * @typedef {array} DeleteLogResponse
    * @property {object} 0 The full API response.
@@ -304,6 +301,9 @@ class Log implements LogSeverityFunctions {
    * region_tag:logging_delete_log
    * Another example:
    */
+  delete(gaxOptions?: CallOptions): Promise<ApiResponse>;
+  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
+  delete(callback: DeleteCallback): void;
   async delete(
     gaxOptions?: CallOptions | DeleteCallback
   ): Promise<ApiResponse> {
@@ -318,12 +318,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  emergency(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  emergency(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "EMERGENCY".
    *
@@ -356,6 +350,12 @@ class Log implements LogSeverityFunctions {
    */
   emergency(
     entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  emergency(entry: Entry | Entry[], callback: ApiResponseCallback): void;
+  emergency(
+    entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
   ): Promise<ApiResponse> {
     return this.write(
@@ -364,9 +364,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  entry(metadata?: LogEntry): Entry;
-  entry(data?: string | {}): Entry;
-  entry(metadata?: LogEntry, data?: string | {}): Entry;
   /**
    * Create an entry object for this log.
    *
@@ -424,6 +421,9 @@ class Log implements LogSeverityFunctions {
    * // }
    * ```
    */
+  entry(metadata?: LogEntry): Entry;
+  entry(data?: string | {}): Entry;
+  entry(metadata?: LogEntry, data?: string | {}): Entry;
   entry(metadataOrData?: LogEntry | string | {}, data?: string | {}) {
     let metadata: LogEntry;
     if (!data && metadataOrData?.hasOwnProperty('httpRequest')) {
@@ -441,13 +441,6 @@ class Log implements LogSeverityFunctions {
     return this.logging.entry(metadata, data);
   }
 
-  error(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  error(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  error(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "ERROR".
    *
@@ -478,6 +471,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  error(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  error(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  error(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   error(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -488,9 +488,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
-  getEntries(callback: GetEntriesCallback): void;
-  getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   /**
    * This method is a wrapper around {module:logging#getEntries}, but with a
    * filter specified to only return entries from this log.
@@ -535,6 +532,9 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  getEntries(options?: GetEntriesRequest): Promise<GetEntriesResponse>;
+  getEntries(callback: GetEntriesCallback): void;
+  getEntries(options: GetEntriesRequest, callback: GetEntriesCallback): void;
   async getEntries(
     opts?: GetEntriesRequest | GetEntriesCallback
   ): Promise<GetEntriesResponse> {
@@ -641,13 +641,6 @@ class Log implements LogSeverityFunctions {
     return this.logging.tailEntries(options);
   }
 
-  info(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  info(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  info(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "INFO".
    *
@@ -678,6 +671,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  info(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  info(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  info(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   info(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -688,13 +688,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  notice(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  notice(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  notice(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "NOTICE".
    *
@@ -725,6 +718,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  notice(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  notice(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  notice(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   notice(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -735,13 +735,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  warning(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  warning(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  warning(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * Write a log entry with a severity of "WARNING".
    *
@@ -772,6 +765,13 @@ class Log implements LogSeverityFunctions {
    * });
    * ```
    */
+  warning(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  warning(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  warning(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   warning(
     entry: Entry | Entry[],
     options?: WriteOptions | ApiResponseCallback
@@ -782,13 +782,6 @@ class Log implements LogSeverityFunctions {
     );
   }
 
-  write(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
-  write(
-    entry: Entry | Entry[],
-    options: WriteOptions,
-    callback: ApiResponseCallback
-  ): void;
-  write(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   /**
    * @typedef {array} LogWriteResponse
    * @property {object} 0 The full API response.
@@ -892,6 +885,13 @@ class Log implements LogSeverityFunctions {
    * region_tag:logging_write_log_entry_advanced
    * Another example:
    */
+  write(entry: Entry | Entry[], options?: WriteOptions): Promise<ApiResponse>;
+  write(
+    entry: Entry | Entry[],
+    options: WriteOptions,
+    callback: ApiResponseCallback
+  ): void;
+  write(entry: Entry | Entry[], callback: ApiResponseCallback): void;
   async write(
     entry: Entry | Entry[],
     opts?: WriteOptions | ApiResponseCallback

--- a/src/sink.ts
+++ b/src/sink.ts
@@ -75,8 +75,6 @@ class Sink {
     this.formattedName_ = 'projects/' + logging.projectId + '/sinks/' + name;
   }
 
-  create(config: CreateSinkRequest): Promise<[Sink, LogSink]>;
-  create(config: CreateSinkRequest, callback: CreateSinkCallback): void;
   /**
    * Create a sink.
    *
@@ -117,13 +115,12 @@ class Sink {
    * region_tag:logging_create_sink
    * Another example:
    */
+  create(config: CreateSinkRequest): Promise<[Sink, LogSink]>;
+  create(config: CreateSinkRequest, callback: CreateSinkCallback): void;
   create(config: CreateSinkRequest): Promise<[Sink, LogSink]> {
     return this.logging.createSink(this.name, config);
   }
 
-  delete(gaxOptions?: CallOptions): Promise<DeleteResponse>;
-  delete(callback: DeleteCallback): void;
-  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   /**
    * @typedef {array} DeleteSinkResponse
    * @property {object} 0 The full API response.
@@ -167,6 +164,9 @@ class Sink {
    * region_tag:logging_delete_sink
    * Another example:
    */
+  delete(gaxOptions?: CallOptions): Promise<DeleteResponse>;
+  delete(callback: DeleteCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   async delete(
     gaxOptions?: CallOptions | DeleteCallback
   ): Promise<DeleteResponse> {
@@ -181,9 +181,6 @@ class Sink {
     );
   }
 
-  getMetadata(gaxOptions?: CallOptions): Promise<SinkMetadataResponse>;
-  getMetadata(callback: SinkMetadataCallback): void;
-  getMetadata(gaxOptions: CallOptions, callback: SinkMetadataCallback): void;
   /**
    * @typedef {array} GetSinkMetadataResponse
    * @property {object} 0 The {@link Sink} metadata.
@@ -226,6 +223,9 @@ class Sink {
    * region_tag:logging_get_sink
    * Another example:
    */
+  getMetadata(gaxOptions?: CallOptions): Promise<SinkMetadataResponse>;
+  getMetadata(callback: SinkMetadataCallback): void;
+  getMetadata(gaxOptions: CallOptions, callback: SinkMetadataCallback): void;
   async getMetadata(
     gaxOptions?: CallOptions | SinkMetadataCallback
   ): Promise<SinkMetadataResponse> {
@@ -242,8 +242,6 @@ class Sink {
     return [this.metadata!];
   }
 
-  setFilter(filter: string): Promise<SinkMetadataResponse>;
-  setFilter(filter: string, callback: SinkMetadataCallback): void;
   /**
    * @typedef {array} SetSinkFilterResponse
    * @property {object} 0 The full API response.
@@ -282,14 +280,14 @@ class Sink {
    * });
    * ```
    */
+  setFilter(filter: string): Promise<SinkMetadataResponse>;
+  setFilter(filter: string, callback: SinkMetadataCallback): void;
   setFilter(filter: string): Promise<SinkMetadataResponse> {
     return this.setMetadata({
       filter,
     });
   }
 
-  setMetadata(metadata: SetSinkMetadata): Promise<SinkMetadataResponse>;
-  setMetadata(metadata: SetSinkMetadata, callback: SinkMetadataCallback): void;
   /**
    * @typedef {array} SetSinkMetadataResponse
    * @property {object} 0 The full API response.
@@ -343,6 +341,8 @@ class Sink {
    * region_tag:logging_update_sink
    * Another example:
    */
+  setMetadata(metadata: SetSinkMetadata): Promise<SinkMetadataResponse>;
+  setMetadata(metadata: SetSinkMetadata, callback: SinkMetadataCallback): void;
   async setMetadata(metadata: SetSinkMetadata): Promise<SinkMetadataResponse> {
     const [currentMetadata] = await this.getMetadata();
     const uniqueWriterIdentity = metadata.uniqueWriterIdentity;


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js
