### PR TITLE
chore: add additional option to populate http request metadata

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -61,3 +61,13 @@ body: |-
   log.alert(entry);
   log.warning(entry);
   ```
+
+  ## Populating Http request metadata
+
+  Metadata about Http request is a part of the [structured log info](https://cloud.google.com/logging/docs/structured-logging)
+  that can be captured within each log entry. It can provide a context for the application logs and
+  is used to group multiple log entries under the load balancer request logs. See the [sample](https://github.com/googleapis/nodejs-logging/blob/master/samples/http-request.js)
+  how to populate the Http request metadata for log entries.
+
+  If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
+  how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ log.alert(entry);
 log.warning(entry);
 ```
 
+## Populating Http request metadata
+
+Metadata about Http request is a part of the [structured log info](https://cloud.google.com/logging/docs/structured-logging)
+that can be captured within each log entry. It can provide a context for the application logs and
+is used to group multiple log entries under the load balancer request logs. See the [sample](https://github.com/googleapis/nodejs-logging/blob/master/samples/http-request.js)
+how to populate the Http request metadata for log entries.
+
+If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
+how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).
+
 
 ## Samples
 


### PR DESCRIPTION
Adds clarification about more than one way to populate Http request metadata of the log entry.

Fixes #1129
