### PR TITLE
fix: log.write removed option.resource.labels

### DIFF
--- a/src/utils/log-common.ts
+++ b/src/utils/log-common.ts
@@ -57,12 +57,18 @@ export function snakecaseKeys(
   labels: {[p: string]: string} | null | undefined
 ) {
   for (const key in labels) {
+    const replaced = key.replace(
+      /[A-Z]/g,
+      letter => `_${letter.toLowerCase()}`
+    );
     Object.defineProperty(
       labels,
-      key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`),
+      replaced,
       Object.getOwnPropertyDescriptor(labels, key) as PropertyDescriptor
     );
-    delete labels[key];
+    if (replaced !== key) {
+      delete labels[key];
+    }
   }
   return labels;
 }

--- a/test/utils/log-common.ts
+++ b/test/utils/log-common.ts
@@ -99,11 +99,13 @@ describe('Log Common', () => {
       const labels = {
         projectId: 'id',
         fooBarBaz: 'foobar',
+        some_other: 'value',
       };
       const result = snakecaseKeys(labels);
       assert.deepStrictEqual(result, {
         project_id: 'id',
         foo_bar_baz: 'foobar',
+        some_other: 'value',
       });
     });
   });

--- a/test/utils/log-common.ts
+++ b/test/utils/log-common.ts
@@ -100,12 +100,14 @@ describe('Log Common', () => {
         projectId: 'id',
         fooBarBaz: 'foobar',
         some_other: 'value',
+        AnotherOne: 'another',
       };
       const result = snakecaseKeys(labels);
       assert.deepStrictEqual(result, {
         project_id: 'id',
         foo_bar_baz: 'foobar',
         some_other: 'value',
+        _another_one: 'another',
       });
     });
   });


### PR DESCRIPTION
The `snakecaseKeys` was always removing labels which were in snake-case

Fixes #[1167](https://github.com/googleapis/nodejs-logging/issues/1167)  🦕
