### PR TITLE
fix: logSync ignores log_id when it generates logName field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import {
   assignSeverityToEntries,
 } from './utils/log-common';
 import {Log, GetEntriesRequest, TailEntriesRequest, LogOptions} from './log';
-import {LogSync} from './log-sync';
+import {LogSync, LogSyncOptions} from './log-sync';
 import {Sink} from './sink';
 import {Duplex, PassThrough, Transform, Writable} from 'stream';
 import {google} from '../protos/protos';
@@ -1251,6 +1251,7 @@ class Logging {
    *
    * @param {string} name Name of the existing log.
    * @param {object} transport An optional write stream.
+   * @param {LogSyncOptions} options Configuration object.
    * @returns {LogSync}
    *
    * @example
@@ -1266,8 +1267,8 @@ class Logging {
    * const log = logging.logSync('my-log');
    * ```
    */
-  logSync(name: string, transport?: Writable) {
-    return new LogSync(this, name, transport);
+  logSync(name: string, transport?: Writable, options?: LogSyncOptions) {
+    return new LogSync(this, name, transport, options);
   }
 
   /**


### PR DESCRIPTION
Adding an ability to wrap all entries logged in LogSync.write with [write requests](https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write).
This fix is controlled by `LogSyncOptions.useWriteRequest` parameter which be default is false

Fixes #<[1207](https://github.com/googleapis/nodejs-logging/issues/1207)> 🦕
