### PR TITLE
fix: Regular error showing Total timeout of API google.logging.v2.LoggingServiceV2 exceeded 600000 milliseconds

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -125,3 +125,4 @@ body: |-
 
     const log = logging.log('my-log', options);
   ``` 
+  See the full sample in `writeLogWithCallback` function [here](https://github.com/googleapis/nodejs-logging/blob/master/samples/logs.js).

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -88,7 +88,8 @@ body: |-
   ```
 
   However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
-  simply adding a callback like in example below:
+  simply adding a callback like in example below - this way the log entry can be queued for processing and code
+  execution will continue without further delays, so callback will be called once operation is complete:
 
   ```js
       // Asynchronously write the log entry and handle respone or any errors in provided callback

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -76,7 +76,7 @@ body: |-
 
   The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
   cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
-  One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
+  One possible way to catch the error is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
 
   ```js
       // Write log entry and and catch any errors
@@ -88,8 +88,8 @@ body: |-
   ```
 
   However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
-  simply adding a callback like in example below - this way the log entry can be queued for processing and code
-  execution will continue without further delays, so callback will be called once operation is complete:
+  simply adding a callback like in the example below. This way the log entry can be queued for processing and code
+  execution will continue without further delays. The callback will be called once the operation is complete:
 
   ```js
       // Asynchronously write the log entry and handle respone or any errors in provided callback

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -71,3 +71,56 @@ body: |-
 
   If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
   how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).
+
+  ## Error handling with logs written or deleted asynchronously
+
+  The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
+  cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
+  One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
+
+  ```js
+      // Write log entry and and catch any errors
+      try {
+        await log.write(entry);
+      } catch (err) {
+        console.log('Error is: ' + err);
+      }
+  ```
+
+  However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
+  simply adding a callback like in example below:
+
+  ```js
+      // Asynchronously write the log entry and handle respone or any errors in provided callback
+      log.write(entry, err => {
+        if (err) {
+          // The log entry was not written.
+          console.log(err.message);
+        } else {
+          console.log('No error in write callback!');
+        }
+      });
+  ```
+
+  Adding a callback to every `log.write` or `log.delete` calls could be a burden, especially if code
+  handling the error is always the same. For this purpose we introduced an ability to provide a default callback
+  for `Log` class which could be set through `LogOptions` passed to `Log` constructor as in example below - this
+  way you can define a global callback once for all `log.write` and `log.delete` calls and be able to handle errors:
+
+  ```js
+    const {Logging} = require('@google-cloud/logging');
+    const logging = new Logging();
+    
+    // Create options with default callback to be called on every write/delete response or error
+    const options = {
+      defaultWriteDeleteCallback: function (err) {
+        if (err) {
+          console.log('Error is: ' + err);
+        } else {
+          console.log('No error, all is good!');
+        }
+      },
+    };
+
+    const log = logging.log('my-log', options);
+  ``` 

--- a/README.md
+++ b/README.md
@@ -162,58 +162,6 @@ how to populate the Http request metadata for log entries.
 If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
 how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).
 
-## Error handling with logs written or deleted asynchronously
-
-The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
-cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
-One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
-
-```js
-    // Write log entry and and catch any errors
-    try {
-      await log.write(entry);
-    } catch (err) {
-      console.log('Error is: ' + err);
-    }
-```
-
-However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
-simply adding a callback like in example below:
-
-```js
-    // Asynchronously write the log entry and handle respone or any errors in provided callback
-    log.write(entry, err => {
-      if (err) {
-        // The log entry was not written.
-        console.log(err.message);
-      } else {
-        console.log('No error in write callback!');
-      }
-    });
-```
-
-Adding a callback to every `log.write` or `log.delete` calls could be a burden, especially if code
-handling the error is always the same. For this purpose we introduced an ability to provide a default callback
-for `Log` class which could be set through `LogOptions` passed to `Log` constructor as in example below - this
-way you can define a global callback once for all `log.write` and `log.delete` calls and be able to handle errors:
-
-```js
-  const {Logging} = require('@google-cloud/logging');
-  const logging = new Logging();
-  
-  // Create options with default callback to be called on every write/delete response or error
-  const options = {
-    defaultWriteDeleteCallback: function (err) {
-      if (err) {
-        console.log('Error is: ' + err);
-      } else {
-        console.log('No error, all is good!');
-      }
-    },
-  };
-
-  const log = logging.log('my-log', options);
-``` 
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,59 @@ how to populate the Http request metadata for log entries.
 If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
 how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).
 
+## Error handling with logs written or deleted asynchronously
+
+The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
+cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
+One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
+
+```js
+    // Write log entry and and catch any errors
+    try {
+      await log.write(entry);
+    } catch (err) {
+      console.log('Error is: ' + err);
+    }
+```
+
+However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
+simply adding a callback like in example below:
+
+```js
+    // Asynchronously write the log entry and handle respone or any errors in provided callback
+    log.write(entry, err => {
+      if (err) {
+        // The log entry was not written.
+        console.log(err.message);
+      } else {
+        console.log('No error in write callback!');
+      }
+    });
+```
+
+Adding a callback to every `log.write` or `log.delete` calls could be a burden, especially if code
+handling the error is always the same. For this purpose we introduced an ability to provide a default callback
+for `Log` class which could be set through `LogOptions` passed to `Log` constructor as in example below - this
+way you can define a global callback once for all `log.write` and `log.delete` calls and be able to handle errors:
+
+```js
+  const {Logging} = require('@google-cloud/logging');
+  const logging = new Logging();
+  
+  // Create options with default callback to be called on every write/delete response or error
+  const options = {
+    defaultWriteDeleteCallback: function (err) {
+      if (err) {
+        console.log('Error is: ' + err);
+      } else {
+        console.log('No error, all is good!');
+      }
+    },
+  };
+
+  const log = logging.log('my-log', options);
+``` 
+
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ how the `request` is interpreted as raw can be found in the [code](https://githu
 
 The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
 cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
-One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
+One possible way to catch the error is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
 
 ```js
     // Write log entry and and catch any errors
@@ -178,8 +178,8 @@ One possible way to catch all errors is to `await` the log write/delete calls an
 ```
 
 However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
-simply adding a callback like in example below - this way the log entry can be queued for processing and code
-execution will continue without further delays, so callback will be called once operation is complete:
+simply adding a callback like in the example below. This way the log entry can be queued for processing and code
+execution will continue without further delays. The callback will be called once the operation is complete:
 
 ```js
     // Asynchronously write the log entry and handle respone or any errors in provided callback

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ One possible way to catch all errors is to `await` the log write/delete calls an
 ```
 
 However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
-simply adding a callback like in example below:
+simply adding a callback like in example below - this way the log entry can be queued for processing and code
+execution will continue without further delays, so callback will be called once operation is complete:
 
 ```js
     // Asynchronously write the log entry and handle respone or any errors in provided callback

--- a/README.md
+++ b/README.md
@@ -162,6 +162,58 @@ how to populate the Http request metadata for log entries.
 If you already have a "raw" Http `request` object you can assign it to `entry.metadata.httpRequest` directly. More information about
 how the `request` is interpreted as raw can be found in the [code](https://github.com/googleapis/nodejs-logging/blob/15849160116a814ab71113138cb211c2e0c2d4b4/src/entry.ts#L224-L238).
 
+## Error handling with logs written or deleted asynchronously
+
+The `Log` class provide users the ability to write and delete logs asynchronously. However, there are cases when log entries
+cannot be written or deleted and error is thrown - if error is not handled properly, it could crash the application.
+One possible way to catch all errors is to `await` the log write/delete calls and wrap it with `try/catch` like in example below:
+
+```js
+    // Write log entry and and catch any errors
+    try {
+      await log.write(entry);
+    } catch (err) {
+      console.log('Error is: ' + err);
+    }
+```
+
+However, awaiting for every `log.write` or `log.delete` calls may introduce delays which could be avoided by 
+simply adding a callback like in example below:
+
+```js
+    // Asynchronously write the log entry and handle respone or any errors in provided callback
+    log.write(entry, err => {
+      if (err) {
+        // The log entry was not written.
+        console.log(err.message);
+      } else {
+        console.log('No error in write callback!');
+      }
+    });
+```
+
+Adding a callback to every `log.write` or `log.delete` calls could be a burden, especially if code
+handling the error is always the same. For this purpose we introduced an ability to provide a default callback
+for `Log` class which could be set through `LogOptions` passed to `Log` constructor as in example below - this
+way you can define a global callback once for all `log.write` and `log.delete` calls and be able to handle errors:
+
+```js
+  const {Logging} = require('@google-cloud/logging');
+  const logging = new Logging();
+  
+  // Create options with default callback to be called on every write/delete response or error
+  const options = {
+    defaultWriteDeleteCallback: function (err) {
+      if (err) {
+        console.log('Error is: ' + err);
+      } else {
+        console.log('No error, all is good!');
+      }
+    },
+  };
+
+  const log = logging.log('my-log', options);
+``` 
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ way you can define a global callback once for all `log.write` and `log.delete` c
 
   const log = logging.log('my-log', options);
 ``` 
+See the full sample in `writeLogWithCallback` function [here](https://github.com/googleapis/nodejs-logging/blob/master/samples/logs.js).
 
 
 ## Samples

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -210,7 +210,6 @@ async function deleteLog(logName) {
 }
 
 async function writeLogWithCallback(logName) {
-  // [START logging_write_log_error_handling]
   const {Logging} = require('@google-cloud/logging');
   const logging = new Logging();
 
@@ -251,7 +250,6 @@ async function writeLogWithCallback(logName) {
     console.log(`Wrote to ${logName}`);
   }
   writeLogEntry();
-  // [END logging_write_log_error_handling]
 }
 
 async function main() {

--- a/samples/logs.js
+++ b/samples/logs.js
@@ -209,6 +209,51 @@ async function deleteLog(logName) {
   // [END logging_delete_log]
 }
 
+async function writeLogWithCallback(logName) {
+  // [START logging_write_log_error_handling]
+  const {Logging} = require('@google-cloud/logging');
+  const logging = new Logging();
+
+  // Create options with default callback to be called on every write/delete response or error
+  const options = {
+    defaultWriteDeleteCallback: function (err) {
+      if (err) {
+        console.log('Error is: ' + err);
+      } else {
+        console.log('No error in default callback!');
+      }
+    },
+  };
+
+  /**
+   * TODO(developer): Uncomment the following line and replace with your values.
+   */
+  // const logName = 'my-log';
+  const log = logging.log(logName, options);
+
+  // A text log entry
+  const text_entry = log.entry('Hello world!');
+
+  async function writeLogEntry() {
+    // Asynchronously write the log entry and handle respone or any errors in provided callback
+    log.write(text_entry, err => {
+      if (err) {
+        // The log entry was not written.
+        console.log(err.message);
+      } else {
+        console.log('No error in write callback!');
+      }
+    });
+
+    // Let the logging library dispatch logs and handle response or any errors in defaultWriteDeleteCallback
+    log.write(text_entry);
+
+    console.log(`Wrote to ${logName}`);
+  }
+  writeLogEntry();
+  // [END logging_write_log_error_handling]
+}
+
 async function main() {
   require('yargs')
     .demand(1)
@@ -278,6 +323,14 @@ async function main() {
       'Write a JSON log entry.'
     )
     .example('node $0 delete my-log', 'Delete "my-log".')
+    .command(
+      'write-callback <logName>',
+      'Writes a text log entry to the specified log and handles response or error in callback.',
+      {},
+      opts => {
+        writeLogWithCallback(opts.logName);
+      }
+    )
     .wrap(120)
     .recommendCommands()
     .epilogue('For more information, see https://cloud.google.com/logging/docs')

--- a/src/log.ts
+++ b/src/log.ts
@@ -91,7 +91,10 @@ export type DeleteCallback = ApiResponseCallback;
  * @param {string[]} [options.jsonFieldsToTruncate] A list of JSON properties at the given full path to be truncated.
  *     Received values will be prepended to predefined list in the order received and duplicates discarded.
  * @param {ApiResponseCallback} [options.defaultWriteDeleteCallback] A default global callback to be used for {@link Log#write}
- *     and {@link Log#delete} APIs when {@link ApiResponseCallback} callback was not supplied by caller as API parameter.
+ *     and {@link Log#delete} APIs when {@link ApiResponseCallback} callback was not supplied by caller in function parameters.
+ *     Note that {@link LogOptions#defaultWriteDeleteCallback} is useful when {@link Log#write} and {@link Log#delete} APIs are called
+ *     without `await` and without callback added explicitly to every call - this way {@link LogOptions#defaultWriteDeleteCallback}
+ *     can serve as global callback handler, which for example could be used to catch all errors and eliminate crashes.
  * @example
  * ```
  * import {Logging} from '@google-cloud/logging';

--- a/src/log.ts
+++ b/src/log.ts
@@ -90,12 +90,25 @@ export type DeleteCallback = ApiResponseCallback;
  * @param {number} [options.maxEntrySize] A max entry size
  * @param {string[]} [options.jsonFieldsToTruncate] A list of JSON properties at the given full path to be truncated.
  *     Received values will be prepended to predefined list in the order received and duplicates discarded.
- *
+ * @param {ApiResponseCallback} [options.defaultWriteDeleteCallback] A default global callback to be used for {@link Log#write}
+ *     and {@link Log#delete} APIs when {@link ApiResponseCallback} callback was not supplied by caller as API parameter.
  * @example
  * ```
- * const {Logging} = require('@google-cloud/logging');
+ * import {Logging} from '@google-cloud/logging';
+ * import {LogOptions} from '@google-cloud/logging/build/src/log';
+ * const options: LogOptions = {
+ *   maxEntrySize: 256,
+ *   jsonFieldsToTruncate: [
+ *     'jsonPayload.fields.metadata.structValue.fields.custom.stringValue',
+ *   ],
+ *   defaultWriteDeleteCallback: (err: any) => {
+ *     if (err) {
+ *       console.log('Error: ' + err);
+ *     }
+ *   },
+ * };
  * const logging = new Logging();
- * const log = logging.log('syslog');
+ * const log = logging.log('syslog', options);
  * ```
  */
 class Log implements LogSeverityFunctions {
@@ -148,8 +161,11 @@ class Log implements LogSeverityFunctions {
       );
     }
 
-    // The default callback for write and delete APIs is going to be used only when
-    // was set by user and only for APIs which does not accept a callback as parameter
+    /**
+     * The default callback for {@link Log#write} and {@link Log#delete} APIs
+     * is going to be used only when {@link LogOptions#defaultWriteDeleteCallback}
+     * was set by user and only for APIs which does not accept a callback as parameter
+     */
     this.defaultWriteDeleteCallback = options.defaultWriteDeleteCallback;
   }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -60,6 +60,7 @@ export interface LogOptions {
   removeCircular?: boolean;
   maxEntrySize?: number; // see: https://cloud.google.com/logging/quotas
   jsonFieldsToTruncate?: string[];
+  defaultWriteDeleteCallback?: ApiResponseCallback;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,6 +105,7 @@ class Log implements LogSeverityFunctions {
   logging: Logging;
   name: string;
   jsonFieldsToTruncate: string[];
+  defaultWriteDeleteCallback?: ApiResponseCallback;
 
   constructor(logging: Logging, name: string, options?: LogOptions) {
     options = options || {};
@@ -145,6 +147,10 @@ class Log implements LogSeverityFunctions {
         this.jsonFieldsToTruncate
       );
     }
+
+    // The default callback for write and delete APIs is going to be used only when
+    // was set by user and only for APIs which does not accept a callback as parameter
+    this.defaultWriteDeleteCallback = options.defaultWriteDeleteCallback;
   }
 
   /**
@@ -347,7 +353,8 @@ class Log implements LogSeverityFunctions {
     };
     return this.logging.loggingService.deleteLog(
       reqOpts,
-      gaxOptions! as CallOptions
+      gaxOptions! as CallOptions,
+      this.defaultWriteDeleteCallback
     );
   }
 
@@ -953,7 +960,8 @@ class Log implements LogSeverityFunctions {
     delete reqOpts.gaxOptions;
     return this.logging.loggingService.writeLogEntries(
       reqOpts,
-      options.gaxOptions
+      options.gaxOptions,
+      this.defaultWriteDeleteCallback
     );
   }
 

--- a/test/log.ts
+++ b/test/log.ts
@@ -169,9 +169,25 @@ describe('Log', () => {
           {
             logName: log.formattedName_,
           },
+          undefined,
           undefined
         )
       );
+    });
+
+    it('should execute global callback for delete', async () => {
+      log.defaultWriteDeleteCallback = () => {};
+      await log.delete();
+      assert(
+        log.logging.loggingService.deleteLog.calledWithExactly(
+          {
+            logName: log.formattedName_,
+          },
+          undefined,
+          log.defaultWriteDeleteCallback
+        )
+      );
+      log.defaultWriteDeleteCallback = undefined;
     });
 
     it('should accept gaxOptions', async () => {
@@ -368,6 +384,7 @@ describe('Log', () => {
               },
             },
           },
+          undefined,
           undefined
         )
       );
@@ -432,6 +449,7 @@ describe('Log', () => {
             entries: ENTRIES,
             resource: EXPECTED_RESOURCE,
           },
+          undefined,
           undefined
         )
       );
@@ -446,9 +464,27 @@ describe('Log', () => {
             entries: ENTRIES,
             resource: FAKE_RESOURCE,
           },
+          undefined,
           undefined
         )
       );
+    });
+
+    it('should call gax write method with global callback', async () => {
+      log.defaultWriteDeleteCallback = () => {};
+      await log.write(ENTRIES, OPTIONS);
+      assert(
+        log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
+          {
+            logName: log.formattedName_,
+            entries: ENTRIES,
+            resource: FAKE_RESOURCE,
+          },
+          undefined,
+          log.defaultWriteDeleteCallback
+        )
+      );
+      log.defaultWriteDeleteCallback = undefined;
     });
 
     it('should decorate the entries', async () => {
@@ -498,6 +534,7 @@ describe('Log', () => {
       assert(
         log.logging.loggingService.writeLogEntries.calledOnceWithExactly(
           sinon.match.object,
+          undefined,
           undefined
         )
       );


### PR DESCRIPTION
This is a proposed fix to accept a global callback for `Log.delete` and `Log.write` methods through `LogOptions`

Fixes #[<1185>](https://github.com/googleapis/nodejs-logging/issues/1185) 🦕
