### PR TITLE
fix: Add installation step for @google-cloud/logging-min NPM package in README

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -4,8 +4,12 @@ introduction: |-
 
   If you require lightweight dependencies, an experimental, minified version of
   this library is available at [@google-cloud/logging-min](https://www.npmjs.com/package/@google-cloud/logging-min).
-  Note: `logging-min` is experimental, and its feature surface is subject to
-  change.
+  Note: `logging-min` is experimental, and its feature surface is subject to change. 
+  To install `@google-cloud/logging-min` library run the following command:
+
+  ```bash
+  npm install @google-cloud/logging-min
+  ```
 body: |-
   ## Batching Writes
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ### Installing the client library
 
+To install `@google-cloud/logging` library run the following command:
+
 ```bash
 npm install @google-cloud/logging
+```
+
+To install `@google-cloud/logging-min` library run the following command:
+
+```bash
+npm install @google-cloud/logging-min
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ monitor, and alert on log data and events from Google Cloud Platform and Amazon 
 
 If you require lightweight dependencies, an experimental, minified version of
 this library is available at [@google-cloud/logging-min](https://www.npmjs.com/package/@google-cloud/logging-min).
-Note: `logging-min` is experimental, and its feature surface is subject to
-change.
+Note: `logging-min` is experimental, and its feature surface is subject to change. 
+To install `@google-cloud/logging-min` library run the following command:
+
+```bash
+npm install @google-cloud/logging-min
+```
 
 
 A comprehensive list of changes in each version may be found in

--- a/README.md
+++ b/README.md
@@ -54,16 +54,8 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ### Installing the client library
 
-To install `@google-cloud/logging` library run the following command:
-
 ```bash
 npm install @google-cloud/logging
-```
-
-To install `@google-cloud/logging-min` library run the following command:
-
-```bash
-npm install @google-cloud/logging-min
 ```
 
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,8 +11,12 @@ monitor, and alert on log data and events from Google Cloud Platform and Amazon 
 
 If you require lightweight dependencies, an experimental, minified version of
 this library is available at [@google-cloud/logging-min](https://www.npmjs.com/package/@google-cloud/logging-min).
-Note: `logging-min` is experimental, and its feature surface is subject to
-change.
+Note: `logging-min` is experimental, and its feature surface is subject to change. 
+To install `@google-cloud/logging-min` library run the following command:
+
+```bash
+npm install @google-cloud/logging-min
+```
 
 ## Table of Contents
 


### PR DESCRIPTION
The NPM page for `@google-cloud/logging-min` is the same as `@google-cloud/logging`. This can cause some confusion on what the difference are and how to install the correct package: `npm install @google-cloud/logging` vs `npm install @google-cloud/logging-min`.

Fixes #[1126](https://github.com/googleapis/nodejs-logging/issues/1126) 🦕
