### PR TITLE
feat: Add support for library instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "npm run compile-protos && npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "presystem-test": "npm run compile",
-    "system-test": "mocha build/system-test --timeout 600000",
+    "system-test": "mocha build/system-test --timeout 900000",
     "pretest": "npm run compile",
     "test": "c8 mocha build/test",
     "precompile": "gts clean",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "npm run compile-protos && npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "presystem-test": "npm run compile",
-    "system-test": "mocha build/system-test --timeout 900000",
+    "system-test": "mocha build/system-test --timeout 600000",
     "pretest": "npm run compile",
     "test": "c8 mocha build/test",
     "precompile": "gts clean",

--- a/src/log-sync.ts
+++ b/src/log-sync.ts
@@ -18,10 +18,10 @@
  * This is a helper library for synchronously writing logs to any transport.
  */
 
-import arrify = require('arrify');
 import {Logging} from '.';
 import {Entry, LABELS_KEY, LogEntry, StructuredJson} from './entry';
 import {Writable} from 'stream';
+import {populatedInstrumentationInfo} from './utils/instrumentation';
 import {
   LogSeverityFunctions,
   assignSeverityToEntries,
@@ -412,7 +412,8 @@ class LogSync implements LogSeverityFunctions {
     let structuredEntries: StructuredJson[];
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     try {
-      structuredEntries = (arrify(entry) as Entry[]).map(entry => {
+      // Make sure to add instrumentation info
+      structuredEntries = (populatedInstrumentationInfo(entry)).map(entry => {
         if (!(entry instanceof Entry)) {
           entry = this.entry(entry);
         }

--- a/src/log-sync.ts
+++ b/src/log-sync.ts
@@ -413,7 +413,7 @@ class LogSync implements LogSeverityFunctions {
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     try {
       // Make sure to add instrumentation info
-      structuredEntries = (populatedInstrumentationInfo(entry)).map(entry => {
+      structuredEntries = populatedInstrumentationInfo(entry).map(entry => {
         if (!(entry instanceof Entry)) {
           entry = this.entry(entry);
         }

--- a/src/log-sync.ts
+++ b/src/log-sync.ts
@@ -21,7 +21,7 @@
 import {Logging} from '.';
 import {Entry, LABELS_KEY, LogEntry, StructuredJson} from './entry';
 import {Writable} from 'stream';
-import {populatedInstrumentationInfo} from './utils/instrumentation';
+import {populateInstrumentationInfo} from './utils/instrumentation';
 import {
   LogSeverityFunctions,
   assignSeverityToEntries,
@@ -413,7 +413,7 @@ class LogSync implements LogSeverityFunctions {
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     try {
       // Make sure to add instrumentation info
-      structuredEntries = populatedInstrumentationInfo(entry).map(entry => {
+      structuredEntries = populateInstrumentationInfo(entry).map(entry => {
         if (!(entry instanceof Entry)) {
           entry = this.entry(entry);
         }

--- a/src/log.ts
+++ b/src/log.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import arrify = require('arrify');
 import {callbackifyAll} from '@google-cloud/promisify';
 import * as dotProp from 'dot-prop';
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
 import {GetEntriesCallback, GetEntriesResponse, Logging} from '.';
 import {Entry, EntryJson, LogEntry} from './entry';
+import {populatedInstrumentationInfo} from './utils/instrumentation';
 import {
   LogSeverityFunctions,
   assignSeverityToEntries,
@@ -964,8 +964,8 @@ class Log implements LogSeverityFunctions {
     await this.logging.setProjectId();
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     const resource = await this.getOrSetResource(options);
-    // Extract & format additional context from individual entries.
-    const decoratedEntries = this.decorateEntries(arrify(entry) as Entry[]);
+    // Extract & format additional context from individual entries. Make sure to add instrumentation info
+    const decoratedEntries = this.decorateEntries(populatedInstrumentationInfo(entry));
     this.truncateEntries(decoratedEntries);
     // Clobber `labels` and `resource` fields with WriteOptions from the user.
     const reqOpts = extend(

--- a/src/log.ts
+++ b/src/log.ts
@@ -21,7 +21,7 @@ import {CallOptions} from 'google-gax';
 import {GetEntriesCallback, GetEntriesResponse, Logging} from '.';
 import {Entry, EntryJson, LogEntry} from './entry';
 import {
-  populatedInstrumentationInfo,
+  populateInstrumentationInfo,
   getInstrumentationInfoStatus,
 } from './utils/instrumentation';
 import {
@@ -977,7 +977,7 @@ class Log implements LogSeverityFunctions {
     const resource = await this.getOrSetResource(options);
     // Extract & format additional context from individual entries. Make sure to add instrumentation info
     const decoratedEntries = this.decorateEntries(
-      populatedInstrumentationInfo(entry)
+      populateInstrumentationInfo(entry)
     );
     this.truncateEntries(decoratedEntries);
     // Clobber `labels` and `resource` fields with WriteOptions from the user.

--- a/src/log.ts
+++ b/src/log.ts
@@ -965,7 +965,9 @@ class Log implements LogSeverityFunctions {
     this.formattedName_ = formatLogName(this.logging.projectId, this.name);
     const resource = await this.getOrSetResource(options);
     // Extract & format additional context from individual entries. Make sure to add instrumentation info
-    const decoratedEntries = this.decorateEntries(populatedInstrumentationInfo(entry));
+    const decoratedEntries = this.decorateEntries(
+      populatedInstrumentationInfo(entry)
+    );
     this.truncateEntries(decoratedEntries);
     // Clobber `labels` and `resource` fields with WriteOptions from the user.
     const reqOpts = extend(

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -108,7 +108,7 @@ export function createDiagnosticEntry(
           {
             // Truncate libraryName and libraryVersion if more than 14 characters length
             name: truncateValue(libraryName),
-            version: truncateValue(libraryVersion ?? getLibraryVersion()),
+            version: truncateValue(libraryVersion ?? getNodejsLibraryVersion()),
           },
         ],
       },
@@ -129,7 +129,7 @@ function validateAndUpdateInstrumentation(
   // First, add current library information
   finalInfo.push({
     name: NODEJS_LIBRARY_NAME_PREFIX,
-    version: getLibraryVersion(),
+    version: getNodejsLibraryVersion(),
   });
   // Iterate through given list of libraries and for each entry perform validations and transformations
   // Limit amount of entries to be up to 3
@@ -164,11 +164,15 @@ function truncateValue(value: string) {
  * since we use {path.resolve}, the search for 'package.json' could be impacted by current working directory.
  * @returns {string} A current library version.
  */
-export function getLibraryVersion() {
+export function getNodejsLibraryVersion() {
   if (libraryVersion) {
     return libraryVersion;
   }
-  libraryVersion = require(path.resolve('package.json')).version;
+  libraryVersion = require(path.resolve(
+    __dirname,
+    '../../../',
+    'package.json'
+  )).version;
   return libraryVersion;
 }
 

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -16,7 +16,7 @@
 
 import arrify = require('arrify');
 import {google} from '../../protos/protos';
-import {Entry, LogEntry} from '../entry';
+import {Entry} from '../entry';
 import version = require('../../package.json');
 
 // The global variable keeping track if instrumentation record was already written or not.
@@ -48,14 +48,11 @@ export function populatedInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
     for (const entryItem of arrify(entry) as any[]) {
       if (entryItem) {
         const info =
-          entryItem.metadata?.jsonPayload?.[DIAGNOSTIC_INFO_KEY]?.[
-            INSTRUMENTATION_SOURCE_KEY
-          ];
+          entryItem.data?.[DIAGNOSTIC_INFO_KEY]?.[INSTRUMENTATION_SOURCE_KEY];
         if (info) {
           // Validate and update the instrumentation info with current library info
-          entryItem.metadata.jsonPayload[DIAGNOSTIC_INFO_KEY][
-            INSTRUMENTATION_SOURCE_KEY
-          ] = validateAndUpdateInstrumentation(info);
+          entryItem.data[DIAGNOSTIC_INFO_KEY][INSTRUMENTATION_SOURCE_KEY] =
+            validateAndUpdateInstrumentation(info);
           // Indicate that instrumentation info log entry already exists
           // and that current library info was added to existing log entry
           isWritten = true;
@@ -94,19 +91,18 @@ export function createDiagnosticEntry(
   }
   const entry = new Entry(
     {
-      jsonPayload: {
-        [DIAGNOSTIC_INFO_KEY]: {
-          [INSTRUMENTATION_SOURCE_KEY]: [
-            {
-              name: truncateValue(libraryName),
-              version: truncateValue(libraryVersion),
-            },
-          ],
-        },
-      },
       severity: google.logging.type.LogSeverity.INFO,
-    } as LogEntry,
-    undefined
+    },
+    {
+      [DIAGNOSTIC_INFO_KEY]: {
+        [INSTRUMENTATION_SOURCE_KEY]: [
+          {
+            name: truncateValue(libraryName),
+            version: truncateValue(libraryVersion),
+          },
+        ],
+      },
+    }
   );
   return entry;
 }

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -198,7 +198,7 @@ function isValidInfo(info: InstrumentationInfo) {
 }
 
 /**
- * The helper method used to reset a status if instrumentation already written.
+ * The helper method used to reset a status of a flag which indicates if instrumentation info already written or not.
  */
 export function resetInstrumentationStatus() {
   global.instrumentationAdded = false;

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -22,7 +22,9 @@ import version = require('../../package.json');
 // The global variable keeping track if instrumentation record was already written or not.
 // The instrumentation record should be generated only once per process and contain logging
 // libraries related info.
-export let instrumentationWritten = false;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const global: {[index: string]: any};
+global.instrumentationAdded = false;
 
 const maxDiagnosticValueLen = 14;
 
@@ -33,6 +35,14 @@ export const NODEJS_LIBRARY_NAME_PREFIX = 'nodejs';
 export type InstrumentationInfo = {name: string; version: string};
 
 /**
+ * This method returns the status if instrumentation info was already added or not.
+ * @returns true if the log record with instrumentation info was already added, false otherwise.
+ */
+export function getInstrumentationInfoStatus() {
+  return global.instrumentationAdded;
+}
+
+/**
  * This method helps to populate entries with instrumentation data
  * @param entry {Entry} The entry or array of entries to be populated with instrumentation info
  * @returns {Entry} Array of entries which contains an entry with current library instrumentation info
@@ -40,8 +50,8 @@ export type InstrumentationInfo = {name: string; version: string};
 export function populatedInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
   // Update the flag indicating that instrumentation entry was already added once,
   // so any subsequent calls to this method will not add a separate instrumentation log entry
-  let isWritten = instrumentationWritten;
-  instrumentationWritten = true;
+  let isWritten = global.instrumentationAdded;
+  global.instrumentationAdded = true;
   const entries: Entry[] = [];
   if (entry) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -170,5 +180,5 @@ function isValidInfo(info: InstrumentationInfo) {
  * The helper method used for tests to reset a status if instrumentation already written.
  */
 export function testResetInstrumentationStatus() {
-  instrumentationWritten = false;
+  global.instrumentationAdded = false;
 }

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -1,0 +1,178 @@
+/*!
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import arrify = require('arrify');
+import {google} from '../../protos/protos';
+import {Entry, LogEntry} from '../entry';
+import version = require('../../package.json');
+
+// The global variable keeping track if instrumentation record was already written or not.
+// The instrumentation record should be generated only once per process and contain logging
+// libraries related info.
+export let instrumentationWritten = false;
+
+const maxDiagnosticValueLen = 14;
+
+export const DIAGNOSTIC_INFO_KEY = 'logging.googleapis.com/diagnostic';
+export const INSTRUMENTATION_SOURCE_KEY = 'instrumentation_source';
+export const NODEJS_LIBRARY_NAME_PREFIX = 'nodejs';
+
+export type InstrumentationInfo = {name: string; version: string};
+
+/**
+ * This method helps to populate entries with instrumentation data
+ * @param entry {Entry} The entry or array of entries to be populated with instrumentation info
+ * @returns {Entry} Array of entries which contains an entry with current library instrumentation info
+ */
+export function populatedInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
+  // Update the flag indicating that instrumentation entry was already added once,
+  // so any subsequent calls to this method will not add a separate instrumentation log entry
+  let isWritten = instrumentationWritten;
+  instrumentationWritten = true;
+  const entries: Entry[] = [];
+  if (entry) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const entryItem of arrify(entry) as any[]) {
+      if (entryItem) {
+        const info =
+          entryItem.metadata?.jsonPayload?.[DIAGNOSTIC_INFO_KEY]?.[
+            INSTRUMENTATION_SOURCE_KEY
+          ];
+        if (info) {
+          // Validate and update the instrumentation info with current library info
+          entryItem.metadata.jsonPayload[DIAGNOSTIC_INFO_KEY][
+            INSTRUMENTATION_SOURCE_KEY
+          ] = validateAndUpdateInstrumentation(info);
+          // Indicate that instrumentation info log entry already exists
+          // and that current library info was added to existing log entry
+          isWritten = true;
+        }
+        entries.push(entryItem);
+      }
+    }
+  }
+  // If no instrumentation info was added before, append a separate log entry with
+  // instrumentation data for this library
+  if (!isWritten) {
+    entries.push(createDiagnosticEntry(undefined, undefined));
+  }
+  return entries;
+}
+
+/**
+ * The helper method to generate a log entry with diagnostic instrumentation data.
+ * @param libraryName {string} The name of the logging library to ve reported. Should be prefixed with 'nodejs'.
+ *        Will be truncated if longer than 14 characters.
+ * @param libraryVersion {string} The version of the logging library to be reported. Will be truncated if longer than 14 characters.
+ * @returns {Entry} The entry with diagnostic instrumentation data.
+ */
+export function createDiagnosticEntry(
+  libraryName: string | undefined,
+  libraryVersion: string | undefined
+): Entry {
+  // Validate the libraryName first and make sure it starts with 'nodejs'
+  // prefix. Truncate if more than 14 characters length
+  if (!libraryName || !libraryName.startsWith(NODEJS_LIBRARY_NAME_PREFIX)) {
+    libraryName = NODEJS_LIBRARY_NAME_PREFIX;
+  }
+  // Validate the libraryVersion and truncate if more than 14 characters length
+  if (!libraryVersion) {
+    libraryVersion = version.version;
+  }
+  const entry = new Entry(
+    {
+      jsonPayload: {
+        [DIAGNOSTIC_INFO_KEY]: {
+          [INSTRUMENTATION_SOURCE_KEY]: [
+            {
+              name: truncateValue(libraryName),
+              version: truncateValue(libraryVersion),
+            },
+          ],
+        },
+      },
+      severity: google.logging.type.LogSeverity.INFO,
+    } as LogEntry,
+    undefined
+  );
+  return entry;
+}
+
+/**
+ * This method validates that provided instrumentation info list is valid and also adds current library info to a list.
+ * @param infoList {InstrumentationInfo} The array of InstrumentationInfo to be validated and updated.
+ * @returns {InstrumentationInfo} The updated list of InstrumentationInfo.
+ */
+function validateAndUpdateInstrumentation(
+  infoList: InstrumentationInfo[]
+): InstrumentationInfo[] {
+  const finalInfo: InstrumentationInfo[] = [];
+  // First, add current library information
+  finalInfo.push({
+    name: NODEJS_LIBRARY_NAME_PREFIX,
+    version: version.version,
+  });
+  // Iterate through given list of libraries and for each entry perform validations and transformations
+  // Limit amount of entries to be up to 3
+  let count = 1;
+  for (const info of infoList) {
+    if (isValidInfo(info)) {
+      finalInfo.push({
+        name: truncateValue(info.name),
+        version: truncateValue(info.version),
+      });
+    }
+    if (++count === 3) break;
+  }
+  return finalInfo;
+}
+
+/**
+ * A helper function to truncate a value (library name or version). The value is truncated
+ * when it is longet than 14 chars and '*' is added instead of truncated suffix.
+ * @param value {string} The library name or version to be truncated.
+ * @returns {string} The truncated value.
+ */
+function truncateValue(value: string) {
+  if (value && value.length > maxDiagnosticValueLen) {
+    return value.substring(0, maxDiagnosticValueLen).concat('*');
+  }
+  return value;
+}
+
+/**
+ * The helper function which checks if given InstrumentationInfo is valid.
+ * @param info {InstrumentationInfo} The info to be validated.
+ * @returns true if given info is valid, false otherwise
+ */
+function isValidInfo(info: InstrumentationInfo) {
+  if (
+    !info ||
+    !info.name ||
+    !info.version ||
+    !info.name.startsWith(NODEJS_LIBRARY_NAME_PREFIX)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The helper method used for tests to reset a status if instrumentation already written.
+ */
+export function testResetInstrumentationStatus() {
+  instrumentationWritten = false;
+}

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -51,7 +51,7 @@ export function getInstrumentationInfoStatus() {
  * @param entry {Entry} The entry or array of entries to be populated with instrumentation info
  * @returns {Entry} Array of entries which contains an entry with current library instrumentation info
  */
-export function populatedInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
+export function populateInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
   // Update the flag indicating that instrumentation entry was already added once,
   // so any subsequent calls to this method will not add a separate instrumentation log entry
   let isWritten = global.instrumentationAdded;
@@ -85,7 +85,7 @@ export function populatedInstrumentationInfo(entry: Entry | Entry[]): Entry[] {
 
 /**
  * The helper method to generate a log entry with diagnostic instrumentation data.
- * @param libraryName {string} The name of the logging library to ve reported. Should be prefixed with 'nodejs'.
+ * @param libraryName {string} The name of the logging library to be reported. Should be prefixed with 'nodejs'.
  *        Will be truncated if longer than 14 characters.
  * @param libraryVersion {string} The version of the logging library to be reported. Will be truncated if longer than 14 characters.
  * @returns {Entry} The entry with diagnostic instrumentation data.
@@ -107,8 +107,11 @@ export function createDiagnosticEntry(
         [INSTRUMENTATION_SOURCE_KEY]: [
           {
             // Truncate libraryName and libraryVersion if more than 14 characters length
-            name: truncateValue(libraryName),
-            version: truncateValue(libraryVersion ?? getNodejsLibraryVersion()),
+            name: truncateValue(libraryName, maxDiagnosticValueLen),
+            version: truncateValue(
+              libraryVersion ?? getNodejsLibraryVersion(),
+              maxDiagnosticValueLen
+            ),
           },
         ],
       },
@@ -137,8 +140,8 @@ function validateAndUpdateInstrumentation(
   for (const info of infoList) {
     if (isValidInfo(info)) {
       finalInfo.push({
-        name: truncateValue(info.name),
-        version: truncateValue(info.version),
+        name: truncateValue(info.name, maxDiagnosticValueLen),
+        version: truncateValue(info.version, maxDiagnosticValueLen),
       });
     }
     if (++count === 3) break;
@@ -147,14 +150,15 @@ function validateAndUpdateInstrumentation(
 }
 
 /**
- * A helper function to truncate a value (library name or version). The value is truncated
- * when it is longet than 14 chars and '*' is added instead of truncated suffix.
- * @param value {string} The library name or version to be truncated.
+ * A helper function to truncate a value (library name or version for example). The value is truncated
+ * when it is longer than {maxLen} chars and '*' is added instead of truncated suffix.
+ * @param value {string} The value to be truncated.
+ * @param maxLen {number} The max length to be used for truncation.
  * @returns {string} The truncated value.
  */
-function truncateValue(value: string) {
-  if (value && value.length > maxDiagnosticValueLen) {
-    return value.substring(0, maxDiagnosticValueLen).concat('*');
+function truncateValue(value: string, maxLen: number) {
+  if (value && value.length > maxLen) {
+    return value.substring(0, maxLen).concat('*');
   }
   return value;
 }
@@ -194,8 +198,8 @@ function isValidInfo(info: InstrumentationInfo) {
 }
 
 /**
- * The helper method used for tests to reset a status if instrumentation already written.
+ * The helper method used to reset a status if instrumentation already written.
  */
-export function testResetInstrumentationStatus() {
+export function resetInstrumentationStatus() {
   global.instrumentationAdded = false;
 }

--- a/system-test/logging.ts
+++ b/system-test/logging.ts
@@ -372,7 +372,8 @@ describe('Logging', () => {
           {numExpectedMessages: logEntries.length},
           (err, entries) => {
             assert.ifError(err);
-            assert.strictEqual(entries!.length, logEntries.length);
+            // Instrumentation log entry is added automatically, so we should discount it
+            assert.strictEqual(entries!.length - 1, logEntries.length);
             done();
           }
         );

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -33,12 +33,10 @@ describe('instrumentation_info', () => {
   });
 
   it('should generate library info properly by default', () => {
-    console.log('The version is: ' + instrumentation.getNodejsLibraryVersion());
     const entry = instrumentation.createDiagnosticEntry(
       undefined,
       undefined
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ) as any;
+    ) as Entry;
     assert.equal(
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
@@ -59,8 +57,7 @@ describe('instrumentation_info', () => {
     assert.equal(entries.length, 2);
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[1] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[1].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
@@ -72,29 +69,25 @@ describe('instrumentation_info', () => {
     const entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.length,
       2
     );
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[NAME],
       NODEJS_TEST
     );
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[VERSION],
       VERSION_TEST
@@ -106,15 +99,13 @@ describe('instrumentation_info', () => {
     const entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.length,
       1
     );
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
@@ -127,15 +118,13 @@ describe('instrumentation_info', () => {
     );
     assert.equal(entries.length, 1);
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[NAME],
       NODEJS_TEST + '-oo*'
     );
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[0].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[1]?.[VERSION],
       VERSION_TEST + '.0.0.0.0.*'
@@ -148,8 +137,7 @@ describe('instrumentation_info', () => {
     assert.equal(entries.length, 2);
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[1] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entries[1].data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -19,7 +19,6 @@ import version = require('../package.json');
 import {Entry} from '../src';
 import * as instrumentation from '../src/utils/instrumentation';
 import {google} from '../protos/protos';
-import {LogEntry} from '../src/entry';
 
 const NAME = 'name';
 const VERSION = 'version';
@@ -41,13 +40,13 @@ describe('instrumentation_info', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any;
     assert.equal(
-      entry.metadata?.jsonPayload?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
-      entry.metadata?.jsonPayload?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+      entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
       version.version
@@ -61,9 +60,9 @@ describe('instrumentation_info', () => {
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[1] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      (entries[1] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
   });
@@ -74,30 +73,30 @@ describe('instrumentation_info', () => {
     assert.equal(entries.length, 1);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.length,
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.length,
       2
     );
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[NAME],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[1]?.[NAME],
       NODEJS_TEST
     );
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[VERSION],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[1]?.[VERSION],
       VERSION_TEST
     );
   });
@@ -108,16 +107,16 @@ describe('instrumentation_info', () => {
     assert.equal(entries.length, 1);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.length,
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.length,
       1
     );
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
   });
@@ -129,16 +128,16 @@ describe('instrumentation_info', () => {
     assert.equal(entries.length, 1);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[NAME],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[1]?.[NAME],
       NODEJS_TEST + '-oo*'
     );
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[0] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[VERSION],
+      (entries[0] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[1]?.[VERSION],
       VERSION_TEST + '.0.0.0.0.*'
     );
   });
@@ -150,9 +149,9 @@ describe('instrumentation_info', () => {
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (entries[1] as any).metadata?.jsonPayload?.[
-        instrumentation.DIAGNOSTIC_INFO_KEY
-      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      (entries[1] as any).data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
     entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
@@ -164,13 +163,12 @@ describe('instrumentation_info', () => {
 function createEntry(name: string | undefined, version: string | undefined) {
   const entry = new Entry(
     {
-      jsonPayload: {},
       severity: google.logging.type.LogSeverity.DEBUG,
-    } as LogEntry,
+    },
     undefined
   );
   if (name || version) {
-    entry.metadata.jsonPayload = {
+    entry.data = {
       [instrumentation.DIAGNOSTIC_INFO_KEY]: {
         [instrumentation.INSTRUMENTATION_SOURCE_KEY]: [
           {

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -1,0 +1,186 @@
+/*!
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import version = require('../package.json');
+import {Entry} from '../src';
+import * as instrumentation from '../src/utils/instrumentation';
+import {google} from '../protos/protos';
+import {LogEntry} from '../src/entry';
+
+const NAME = 'name';
+const VERSION = 'version';
+const NODEJS_TEST = instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-test';
+const LONG_NODEJS_TEST =
+  instrumentation.NODEJS_LIBRARY_NAME_PREFIX + '-test-ooooooooooooooo';
+const VERSION_TEST = '1.0.0';
+const LONG_VERSION_TEST = VERSION_TEST + '.0.0.0.0.0.0.0.0.11.1.1-ALPHA';
+
+describe('instrumentation_info', () => {
+  beforeEach(() => {
+    instrumentation.testResetInstrumentationStatus();
+  });
+
+  it('should generate library info properly by default', () => {
+    const entry = instrumentation.createDiagnosticEntry(
+      undefined,
+      undefined
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+    assert.equal(
+      entry.metadata?.jsonPayload?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[NAME],
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
+    );
+    assert.equal(
+      entry.metadata?.jsonPayload?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
+        instrumentation.INSTRUMENTATION_SOURCE_KEY
+      ]?.[0]?.[VERSION],
+      version.version
+    );
+  });
+
+  it('should add instrumentation log entry to the list', () => {
+    const dummyEntry = createEntry(undefined, undefined);
+    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    assert.equal(entries.length, 2);
+    assert.deepEqual(dummyEntry, entries[0]);
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[1] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
+    );
+  });
+
+  it('should add instrumentation info to existing list', () => {
+    const dummyEntry = createEntry(NODEJS_TEST, VERSION_TEST);
+    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    assert.equal(entries.length, 1);
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.length,
+      2
+    );
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
+    );
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[NAME],
+      NODEJS_TEST
+    );
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[VERSION],
+      VERSION_TEST
+    );
+  });
+
+  it('should replace instrumentation log entry in the list', () => {
+    const dummyEntry = createEntry('nodejs-test', undefined);
+    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    assert.equal(entries.length, 1);
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.length,
+      1
+    );
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
+    );
+  });
+
+  it('should truncate instrumentation info in log entry', () => {
+    const entries = instrumentation.populatedInstrumentationInfo(
+      createEntry(LONG_NODEJS_TEST, LONG_VERSION_TEST)
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[NAME],
+      NODEJS_TEST + '-oo*'
+    );
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[0] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[1]?.[VERSION],
+      VERSION_TEST + '.0.0.0.0.*'
+    );
+  });
+
+  it('should add instrumentation log entry only once', () => {
+    const dummyEntry = createEntry(undefined, undefined);
+    var entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    assert.equal(entries.length, 2);
+    assert.deepEqual(dummyEntry, entries[0]);
+    assert.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entries[1] as any).metadata?.jsonPayload?.[
+        instrumentation.DIAGNOSTIC_INFO_KEY
+      ]?.[instrumentation.INSTRUMENTATION_SOURCE_KEY]?.[0]?.[NAME],
+      instrumentation.NODEJS_LIBRARY_NAME_PREFIX
+    );
+    entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    assert.equal(entries.length, 1);
+    assert.deepEqual(dummyEntry, entries[0]);
+  });  
+});
+
+function createEntry(name: string | undefined, version: string | undefined) {
+  const entry = new Entry(
+    {
+      jsonPayload: {},
+      severity: google.logging.type.LogSeverity.DEBUG,
+    } as LogEntry,
+    undefined
+  );
+  if (name || version) {
+    entry.metadata.jsonPayload = {
+      [instrumentation.DIAGNOSTIC_INFO_KEY]: {
+        [instrumentation.INSTRUMENTATION_SOURCE_KEY]: [
+          {
+            name: name,
+            version: version,
+          },
+        ],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+  return entry;
+}

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -15,7 +15,6 @@
  */
 
 import * as assert from 'assert';
-import version = require('../package.json');
 import {Entry} from '../src';
 import * as instrumentation from '../src/utils/instrumentation';
 import {google} from '../protos/protos';
@@ -34,6 +33,7 @@ describe('instrumentation_info', () => {
   });
 
   it('should generate library info properly by default', () => {
+    console.log('The version is: ' + instrumentation.getLibraryVersion());
     const entry = instrumentation.createDiagnosticEntry(
       undefined,
       undefined
@@ -49,7 +49,7 @@ describe('instrumentation_info', () => {
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      version.version
+      instrumentation.getLibraryVersion()
     );
   });
 

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -29,7 +29,7 @@ const LONG_VERSION_TEST = VERSION_TEST + '.0.0.0.0.0.0.0.0.11.1.1-ALPHA';
 
 describe('instrumentation_info', () => {
   beforeEach(() => {
-    instrumentation.testResetInstrumentationStatus();
+    instrumentation.resetInstrumentationStatus();
   });
 
   it('should generate library info properly by default', () => {
@@ -55,7 +55,7 @@ describe('instrumentation_info', () => {
 
   it('should add instrumentation log entry to the list', () => {
     const dummyEntry = createEntry(undefined, undefined);
-    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    const entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 2);
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
@@ -69,7 +69,7 @@ describe('instrumentation_info', () => {
 
   it('should add instrumentation info to existing list', () => {
     const dummyEntry = createEntry(NODEJS_TEST, VERSION_TEST);
-    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    const entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,7 +103,7 @@ describe('instrumentation_info', () => {
 
   it('should replace instrumentation log entry in the list', () => {
     const dummyEntry = createEntry('nodejs-test', undefined);
-    const entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    const entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.equal(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -122,7 +122,7 @@ describe('instrumentation_info', () => {
   });
 
   it('should truncate instrumentation info in log entry', () => {
-    const entries = instrumentation.populatedInstrumentationInfo(
+    const entries = instrumentation.populateInstrumentationInfo(
       createEntry(LONG_NODEJS_TEST, LONG_VERSION_TEST)
     );
     assert.equal(entries.length, 1);
@@ -144,7 +144,7 @@ describe('instrumentation_info', () => {
 
   it('should add instrumentation log entry only once', () => {
     const dummyEntry = createEntry(undefined, undefined);
-    let entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    let entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 2);
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
@@ -154,7 +154,7 @@ describe('instrumentation_info', () => {
       ]?.[0]?.[NAME],
       instrumentation.NODEJS_LIBRARY_NAME_PREFIX
     );
-    entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    entries = instrumentation.populateInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.deepEqual(dummyEntry, entries[0]);
   });

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -33,7 +33,7 @@ describe('instrumentation_info', () => {
   });
 
   it('should generate library info properly by default', () => {
-    console.log('The version is: ' + instrumentation.getLibraryVersion());
+    console.log('The version is: ' + instrumentation.getNodejsLibraryVersion());
     const entry = instrumentation.createDiagnosticEntry(
       undefined,
       undefined
@@ -49,7 +49,7 @@ describe('instrumentation_info', () => {
       entry.data?.[instrumentation.DIAGNOSTIC_INFO_KEY]?.[
         instrumentation.INSTRUMENTATION_SOURCE_KEY
       ]?.[0]?.[VERSION],
-      instrumentation.getLibraryVersion()
+      instrumentation.getNodejsLibraryVersion()
     );
   });
 

--- a/test/instrumentation.ts
+++ b/test/instrumentation.ts
@@ -145,7 +145,7 @@ describe('instrumentation_info', () => {
 
   it('should add instrumentation log entry only once', () => {
     const dummyEntry = createEntry(undefined, undefined);
-    var entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
+    let entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 2);
     assert.deepEqual(dummyEntry, entries[0]);
     assert.equal(
@@ -158,7 +158,7 @@ describe('instrumentation_info', () => {
     entries = instrumentation.populatedInstrumentationInfo(dummyEntry);
     assert.equal(entries.length, 1);
     assert.deepEqual(dummyEntry, entries[0]);
-  });  
+  });
 });
 
 function createEntry(name: string | undefined, version: string | undefined) {

--- a/test/utils/metadata.ts
+++ b/test/utils/metadata.ts
@@ -65,7 +65,6 @@ describe('metadata', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let metadata: any;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let AUTH;
   const ENV_CACHED = extend({}, process.env);
 
   const INITIAL_ENV: {[key: string]: string | undefined} = {};
@@ -80,7 +79,6 @@ describe('metadata', () => {
   });
 
   beforeEach(() => {
-    AUTH = {};
     extend(metadata, metadataCached);
     instanceOverride = null;
     readFileShouldError = false;


### PR DESCRIPTION
This feature provides an ability to log extra entry with diagnostics structure which contains logging library information. Such entry is logged only once when first entry is written by a process using logging library.

Fixes #[1286](https://github.com/googleapis/nodejs-logging/issues/1286) 🦕
