### PR TITLE
fix: Logging to stdout in Cloud Run creates a JSON object as "message"

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -275,12 +275,19 @@ class Entry {
         ? meta.traceSampled
         : undefined;
     // Format log payload.
-    let data =
-      meta.textPayload || meta.jsonPayload || meta.protoPayload || undefined;
+    const data =
+      this.data ||
+      meta.textPayload ||
+      meta.jsonPayload ||
+      meta.protoPayload ||
+      undefined;
     if (useMessageField) {
-      entry.message = this.data || data;
+      /** If useMessageField is set, we add the payload to {@link StructuredJson#message} field.*/
+      entry.message = data;
     } else {
-      data = this.data || data;
+      /** useMessageField is false, we add the structured payload to {@link StructuredJson} key-value map.
+       * It could be especially useful for serverless environments like Cloud Run/Functions when stdout transport is used.
+       * Note that text still added to {@link StructuredJson#message} field for text payload since it does not have fields within. */
       if (data !== undefined && data !== null) {
         if (this.isObject(data)) {
           entry = extend(true, {}, entry, data);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -245,7 +245,7 @@ class Entry {
    * Serialize an entry to a standard format for any transports, e.g. agents.
    * Read more: https://cloud.google.com/logging/docs/structured-logging
    */
-  toStructuredJSON(projectId = '', useMessageStructure = true) {
+  toStructuredJSON(projectId = '', useMessageField = true) {
     const meta = this.metadata;
     // Mask out the keys that need to be renamed.
     /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -277,7 +277,7 @@ class Entry {
     // Format log payload.
     let data =
       meta.textPayload || meta.jsonPayload || meta.protoPayload || undefined;
-    if (useMessageStructure) {
+    if (useMessageField) {
       entry.message = this.data || data;
     } else {
       data = this.data || data;

--- a/src/log-sync.ts
+++ b/src/log-sync.ts
@@ -31,7 +31,9 @@ import {
 } from './utils/log-common';
 
 export interface LogSyncOptions {
-  useMessageStructure?: boolean;
+  // The flag indicating if "message" field should be used to store structured,
+  // non-text data inside jsonPayload field. By default this value is true
+  useMessageField?: boolean;
 }
 
 /**
@@ -65,7 +67,7 @@ class LogSync implements LogSeverityFunctions {
   logging: Logging;
   name: string;
   transport: Writable;
-  useMessageStructure_: boolean;
+  useMessageField_: boolean;
 
   // not projectId, formattedname is expected
   constructor(
@@ -84,7 +86,7 @@ class LogSync implements LogSeverityFunctions {
     this.name = this.formattedName_.split('/').pop()!;
     // Default to writing to stdout
     this.transport = transport || process.stdout;
-    this.useMessageStructure_ = options.useMessageStructure === true;
+    this.useMessageField_ = options.useMessageField ?? true;
   }
 
   /**
@@ -431,7 +433,7 @@ class LogSync implements LogSeverityFunctions {
         }
         return entry.toStructuredJSON(
           this.logging.projectId,
-          this.useMessageStructure_
+          this.useMessageField_
         );
       });
       for (const entry of structuredEntries) {

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -368,5 +368,17 @@ describe('Entry', () => {
       assert.strictEqual(json[entryTypes.SPAN_ID_KEY], '1');
       assert.strictEqual(json[entryTypes.TRACE_SAMPLED_KEY], false);
     });
+
+    it('should add message wrapper for structured data', () => {
+      entry.data = {message: 'message', test: 'test'};
+      let json = entry.toStructuredJSON();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assert(((json.message as any).message = 'message'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assert(((json.message as any).test = 'test'));
+      json = entry.toStructuredJSON(undefined, false);
+      assert((json.message = 'message'));
+      assert((json.test = 'test'));
+    });
   });
 });

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -369,7 +369,7 @@ describe('Entry', () => {
       assert.strictEqual(json[entryTypes.TRACE_SAMPLED_KEY], false);
     });
 
-    it('should add message wrapper for structured data', () => {
+    it('should add message field for structured data', () => {
       entry.data = {message: 'message', test: 'test'};
       let json = entry.toStructuredJSON();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -379,6 +379,17 @@ describe('Entry', () => {
       json = entry.toStructuredJSON(undefined, false);
       assert((json.message = 'message'));
       assert((json.test = 'test'));
+    });
+
+    it('should add message field only when needed', () => {
+      entry.data = 1;
+      let json = entry.toStructuredJSON();
+      assert((json.message = '1'));
+      json = entry.toStructuredJSON(undefined, false);
+      assert((json.message = '1'));
+      entry.data = 'test';
+      json = entry.toStructuredJSON(undefined, false);
+      assert((json.message = 'test'));
     });
   });
 });


### PR DESCRIPTION
This is a fix to provide a configurable way to disable "message" wrapper added for structured log data when LogSync is used for logged entries

Fixes #<[1301](https://github.com/googleapis/nodejs-logging/issues/1301)> 🦕
