### PR TITLE
chore(tests): install auth plugin for k8s tests

### DIFF
--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -80,6 +80,7 @@ fi
 # If Kubernetes, install kubectl component
 if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
   gcloud components install kubectl -q
+  gcloud components install gke-gcloud-auth-plugin -q
 fi
 
 # Run the specified environment test

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -81,6 +81,7 @@ fi
 if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
   gcloud components install kubectl -q
   gcloud components install gke-gcloud-auth-plugin -q
+  export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 fi
 
 # Run the specified environment test


### PR DESCRIPTION
The GKE environment test is currently failing due to missing the (newly required) GKE auth plugin in the test runner container. This PR adds the missing dependency