### PR TITLE
fix: Correction for timestamp and instrumentation record severity fields format

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -22,7 +22,7 @@ import {
   objToStruct,
   structToObj,
   zuluToDateObj,
-  toNanoSecondsObj,
+  toNanosAndSecondsObj,
 } from './utils/common';
 import {
   makeHttpRequestData,
@@ -81,7 +81,7 @@ export interface StructuredJson {
   message?: string | object;
   httpRequest?: object;
   // Based on https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing, the
-  // timestamp should be in nanoseconds format.
+  // timestamp should be in nanos and seconds format.
   timestamp?: Timestamp;
   [INSERT_ID_KEY]?: string;
   [OPERATION_KEY]?: object;
@@ -221,7 +221,7 @@ class Entry {
     }
     // Format log timestamp
     if (entry.timestamp instanceof Date) {
-      entry.timestamp = toNanoSecondsObj(entry.timestamp);
+      entry.timestamp = toNanosAndSecondsObj(entry.timestamp);
     } else if (typeof entry.timestamp === 'string') {
       entry.timestamp = zuluToDateObj(entry.timestamp);
     }
@@ -302,7 +302,7 @@ class Entry {
     }
     // Format timestamp
     if (meta.timestamp instanceof Date) {
-      entry.timestamp = toNanoSecondsObj(meta.timestamp);
+      entry.timestamp = toNanosAndSecondsObj(meta.timestamp);
     }
     // Format httprequest
     const req = meta.httpRequest;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -18,7 +18,12 @@
 const EventId = require('eventid');
 import * as extend from 'extend';
 import {google} from '../protos/protos';
-import {objToStruct, structToObj, zuluToDateObj} from './utils/common';
+import {
+  objToStruct,
+  structToObj,
+  zuluToDateObj,
+  toNanoSecondsObj,
+} from './utils/common';
 import {
   makeHttpRequestData,
   CloudLoggingHttpRequest,
@@ -75,7 +80,9 @@ export interface StructuredJson {
   // Universally supported properties
   message?: string | object;
   httpRequest?: object;
-  timestamp?: string;
+  // Based on https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing, the
+  // timestamp should be in nanoseconds format.
+  timestamp?: Timestamp;
   [INSERT_ID_KEY]?: string;
   [OPERATION_KEY]?: object;
   [SOURCE_LOCATION_KEY]?: object;
@@ -214,12 +221,7 @@ class Entry {
     }
     // Format log timestamp
     if (entry.timestamp instanceof Date) {
-      const seconds = entry.timestamp.getTime() / 1000;
-      const secondsRounded = Math.floor(seconds);
-      entry.timestamp = {
-        seconds: secondsRounded,
-        nanos: Math.floor((seconds - secondsRounded) * 1e9),
-      };
+      entry.timestamp = toNanoSecondsObj(entry.timestamp);
     } else if (typeof entry.timestamp === 'string') {
       entry.timestamp = zuluToDateObj(entry.timestamp);
     }
@@ -300,7 +302,7 @@ class Entry {
     }
     // Format timestamp
     if (meta.timestamp instanceof Date) {
-      entry.timestamp = meta.timestamp.toISOString();
+      entry.timestamp = toNanoSecondsObj(meta.timestamp);
     }
     // Format httprequest
     const req = meta.httpRequest;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -243,3 +243,17 @@ export function zuluToDateObj(zuluTime: string) {
     nanos: nanoSecs ? Number(nanoSecs.padEnd(9, '0')) : 0,
   };
 }
+
+/**
+ * Converts Date to nanoseconds format suported by Logging.
+ * See https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing for more details
+ * @param date The date to be converted to Logging nanoseconds format
+ */
+export function toNanoSecondsObj(date: Date) {
+  const seconds = date.getTime() / 1000;
+  const secondsRounded = Math.floor(seconds);
+  return {
+    seconds: secondsRounded,
+    nanos: Math.floor((seconds - secondsRounded) * 1e9),
+  };
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -249,7 +249,7 @@ export function zuluToDateObj(zuluTime: string) {
  * See https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing for more details
  * @param date The date to be converted to Logging nanoseconds format
  */
-export function toNanoSecondsObj(date: Date) {
+export function toNanosAndSecondsObj(date: Date) {
   const seconds = date.getTime() / 1000;
   const secondsRounded = Math.floor(seconds);
   return {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -247,7 +247,7 @@ export function zuluToDateObj(zuluTime: string) {
 /**
  * Converts Date to nanoseconds format suported by Logging.
  * See https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing for more details
- * @param date The date to be converted to Logging nanoseconds format
+ * @param date The date to be converted to Logging nanos and seconds format
  */
 export function toNanosAndSecondsObj(date: Date) {
   const seconds = date.getTime() / 1000;

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -16,7 +16,6 @@
 
 import arrify = require('arrify');
 import path = require('path');
-import {google} from '../../protos/protos';
 import {Entry} from '../entry';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,25 +94,20 @@ export function createDiagnosticEntry(
   if (!libraryName || !libraryName.startsWith(NODEJS_LIBRARY_NAME_PREFIX)) {
     libraryName = NODEJS_LIBRARY_NAME_PREFIX;
   }
-  const entry = new Entry(
-    {
-      severity: google.logging.type.LogSeverity.INFO,
+  const entry = new Entry(undefined, {
+    [DIAGNOSTIC_INFO_KEY]: {
+      [INSTRUMENTATION_SOURCE_KEY]: [
+        {
+          // Truncate libraryName and libraryVersion if more than 14 characters length
+          name: truncateValue(libraryName, maxDiagnosticValueLen),
+          version: truncateValue(
+            libraryVersion ?? getNodejsLibraryVersion(),
+            maxDiagnosticValueLen
+          ),
+        },
+      ],
     },
-    {
-      [DIAGNOSTIC_INFO_KEY]: {
-        [INSTRUMENTATION_SOURCE_KEY]: [
-          {
-            // Truncate libraryName and libraryVersion if more than 14 characters length
-            name: truncateValue(libraryName, maxDiagnosticValueLen),
-            version: truncateValue(
-              libraryVersion ?? getNodejsLibraryVersion(),
-              maxDiagnosticValueLen
-            ),
-          },
-        ],
-      },
-    }
-  );
+  });
   return entry;
 }
 

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -56,11 +56,11 @@ function withinExpectedTimeBoundaries(result?: Date): boolean {
   return false;
 }
 
-function nanosecondsToDate(timestamp: entryTypes.Timestamp) {
+function nanosAndSecondsToDate(timestamp: entryTypes.Timestamp) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const seconds = (timestamp as any).seconds;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const nanos = (timestamp as any).seconds;
+  const nanos = (timestamp as any).nanos;
   return new Date(seconds * 1000 + nanos / 1e9);
 }
 
@@ -328,9 +328,7 @@ describe('Entry', () => {
       entry.data = 'this is a log';
       const json = entry.toStructuredJSON();
       assert(
-        withinExpectedTimeBoundaries(
-          new Date(nanosecondsToDate(json.timestamp!))
-        )
+        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!))
       );
       delete json.timestamp;
       const expectedJSON = {
@@ -358,9 +356,7 @@ describe('Entry', () => {
       entry.metadata.timestamp = new Date();
       const json = entry.toStructuredJSON();
       assert(
-        withinExpectedTimeBoundaries(
-          new Date(nanosecondsToDate(json.timestamp!))
-        )
+        withinExpectedTimeBoundaries(nanosAndSecondsToDate(json.timestamp!))
       );
     });
 

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -56,6 +56,14 @@ function withinExpectedTimeBoundaries(result?: Date): boolean {
   return false;
 }
 
+function nanosecondsToDate(timestamp: entryTypes.Timestamp) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seconds = (timestamp as any).seconds;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nanos = (timestamp as any).seconds;
+  return new Date(seconds * 1000 + nanos / 1e9);
+}
+
 describe('Entry', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let Entry: typeof entryTypes.Entry;
@@ -319,7 +327,11 @@ describe('Entry', () => {
       entry.metadata.traceSampled = false;
       entry.data = 'this is a log';
       const json = entry.toStructuredJSON();
-      assert(withinExpectedTimeBoundaries(new Date(json.timestamp!)));
+      assert(
+        withinExpectedTimeBoundaries(
+          new Date(nanosecondsToDate(json.timestamp!))
+        )
+      );
       delete json.timestamp;
       const expectedJSON = {
         [entryTypes.INSERT_ID_KEY]: '👀',
@@ -345,7 +357,11 @@ describe('Entry', () => {
     it('should convert a string timestamp', () => {
       entry.metadata.timestamp = new Date();
       const json = entry.toStructuredJSON();
-      assert(withinExpectedTimeBoundaries(new Date(json.timestamp!)));
+      assert(
+        withinExpectedTimeBoundaries(
+          new Date(nanosecondsToDate(json.timestamp!))
+        )
+      );
     });
 
     it('should convert a raw http to httprequest', () => {


### PR DESCRIPTION
It seems that `timestamp` format for log records printed to stdout are in wrong format - the right format is defined here: [timestamp-processing](https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing). Worth mentioning that changing this format should be safe despite a fact that `StructuredJson` defined as external - it is used internally and I believe it is safe to change format of `timestamp`.
Also instrumentation record was setting `severity` as number and since it should be with `DEFAULT` severity, removing it from instrumentation record.

Related to # [1266](https://github.com/googleapis/nodejs-logging/issues/1266) 🦕
