### PR TITLE
fix: add CLOUDSDK_PYTHON env var to environment tests

### DIFF
--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -45,6 +45,8 @@ cd "env-tests-logging/"
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
+export CLOUDSDK_PYTHON=python3
+
 # Debug: show build environment
 env | grep KOKORO
 


### PR DESCRIPTION
Fixes failing Kubernetes environment tests by adding the CLOUDSDK_PYTHON environment variable
