### PR TITLE
chore: update environment test submodule

### DIFF
--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -43,7 +43,6 @@ git submodule update --init --recursive
 cd "env-tests-logging/"
 export ENV_TEST_PY_VERSION=3.7
 echo "using python version: $ENV_TEST_PY_VERSION"
-python3 --version
 
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -88,7 +88,7 @@ fi
 
 # Run the specified environment test
 set +e
-nox --python 3.10 --session "tests(language='nodejs', platform='$ENVIRONMENT')"
+nox --session "tests(language='nodejs', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -41,6 +41,9 @@ npm run compile
 # make sure submodule is up to date
 git submodule update --init --recursive
 cd "env-tests-logging/"
+export ENV_TEST_PY_VERSION=3.7
+echo "using python version: $ENV_TEST_PY_VERSION"
+python3 --version
 
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -88,7 +88,7 @@ fi
 
 # Run the specified environment test
 set +e
-nox --python 3.7 --session "tests(language='nodejs', platform='$ENVIRONMENT')"
+nox --python 3.10 --session "tests(language='nodejs', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -88,7 +88,7 @@ fi
 
 # Run the specified environment test
 set +e
-nox --session "tests(language='nodejs', platform='$ENVIRONMENT')"
+python3 -m nox --session "tests(language='nodejs', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources

--- a/.kokoro/environment.sh
+++ b/.kokoro/environment.sh
@@ -24,7 +24,7 @@ if [[ -z "${ENVIRONMENT:-}" ]]; then
 fi
 
 # Setup service account credentials.
-export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secret_manager/long-door-651-kokoro-system-test-service-account
 export GCLOUD_PROJECT=long-door-651
 gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 

--- a/.kokoro/environment/common.cfg
+++ b/.kokoro/environment/common.cfg
@@ -39,3 +39,8 @@ env_vars: {
     key: "LANGUAGE_LABEL"
     value: "nodejs"
 }
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "long-door-651-kokoro-system-test-service-account"
+}

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The environment tests are currently failing due to an upgrade to a [new authentication method](https://github.com/googleapis/nodejs-logging/commit/c5ed8ad59ec58fd2eb3bc7fbcdb0ca7fabcea42d). 

This PR updates the tests to use the new keys, and updates the environment test submodule
