### PR TITLE
fix(deps): bump `google-gax` to ^3.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "extend": "^3.0.2",
     "gcp-metadata": "^4.0.0",
     "google-auth-library": "^8.0.2",
-    "google-gax": "^3.5.2",
+    "google-gax": "^3.5.8",
     "on-finished": "^2.3.0",
     "pumpify": "^2.0.1",
     "stream-events": "^1.0.5",


### PR DESCRIPTION
Fixes dependency vulnerability in google-gax -> protobufjs-cli

Based on #https://github.com/googleapis/google-cloud-node/issues/4116 
Fixes  https://github.com/googleapis/nodejs-logging/issues/1405 🦕 
See also https://github.com/googleapis/google-cloud-node/pull/4117
