### PR TITLE
fix: retreive log entries from logging bucket

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -593,9 +593,13 @@ class Logging {
     reqOpts.resourceNames = arrify(reqOpts.resourceNames!);
     this.projectId = await this.auth.getProjectId();
     const resourceName = 'projects/' + this.projectId;
-    if (reqOpts.resourceNames.indexOf(resourceName) === -1) {
-      reqOpts.resourceNames.push(resourceName);
-    }
+    const isReadFromBucket = reqOpts.resourceNames.some(resourceName =>
+      resourceName.startsWith(resourceName)
+    );
+    if (
+      reqOpts.resourceNames.indexOf(resourceName) === -1 &&
+      !isReadFromBucket
+    ) {
     delete reqOpts.autoPaginate;
     delete reqOpts.gaxOptions;
     let gaxOptions = extend(

--- a/test/index.ts
+++ b/test/index.ts
@@ -616,6 +616,30 @@ describe('Logging', () => {
       await logging.getEntries(options);
     });
 
+    it('should not push project id if include logging bucket view', async () => {
+      const options = {
+        resourceNames: [
+          'projects/' +
+            logging.projectId +
+            '/locations/global/buckets/test-bucket/views/test-view',
+        ],
+      };
+
+      logging.loggingService.listLogEntries = async (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        reqOpts: any
+      ) => {
+        assert.deepStrictEqual(reqOpts.resourceNames, [
+          'projects/' +
+            logging.projectId +
+            '/locations/global/buckets/test-bucket/views/test-view',
+        ]);
+        return [[]];
+      };
+
+      await logging.getEntries(options);
+    });
+
     describe('error', () => {
       const error = new Error('Error.');
 


### PR DESCRIPTION
I also attempted to retrieve log entries from the logging bucket similar #1411, but couldn’t. 

According to [this document](https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list), specify views in `resourceNames` for entries from logging buckets, as an alternative to parent resources.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1411 🦕
