### PR TITLE
fix: serviceContext detection for Cloud Function and Cloud Run

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -222,7 +222,8 @@ export async function detectServiceContext(
       };
     case GCPEnv.CLOUD_FUNCTIONS:
       return {
-        service: process.env.FUNCTION_NAME,
+        service: process.env.K_SERVICE || process.env.FUNCTION_NAME,
+        version: process.env.K_REVISION,
       };
     // On Kubernetes we use the pod-name to describe the service. Currently,
     // we acquire the pod-name from within the pod through env var `HOSTNAME`.
@@ -233,6 +234,7 @@ export async function detectServiceContext(
     case GCPEnv.CLOUD_RUN:
       return {
         service: process.env.K_SERVICE,
+        version: process.env.K_REVISION,
       };
     case GCPEnv.COMPUTE_ENGINE:
       return null;

--- a/test/utils/metadata.ts
+++ b/test/utils/metadata.ts
@@ -587,6 +587,8 @@ describe('metadata', () => {
 
     it('should return the correct descriptor for Cloud Functions', async () => {
       const FUNCTION_NAME = (process.env.FUNCTION_NAME = 'function-name');
+      const K_SERVICE = (process.env.K_SERVICE = 'k-service');
+      const K_REVISION = (process.env.K_REVISION = 'k-revision');
 
       const fakeAuth = {
         async getEnv() {
@@ -595,12 +597,20 @@ describe('metadata', () => {
       };
 
       const sc1 = await metadata.detectServiceContext(fakeAuth);
-      assert.deepStrictEqual(sc1, {service: FUNCTION_NAME});
+      assert.deepStrictEqual(sc1, {service: K_SERVICE, version: K_REVISION});
+
+      delete process.env.K_SERVICE;
+      const sc2 = await metadata.detectServiceContext(fakeAuth);
+      assert.deepStrictEqual(sc2, {
+        service: FUNCTION_NAME,
+        version: K_REVISION,
+      });
     });
 
     it('should return the correct descriptor for Cloud Run', async () => {
       process.env.K_CONFIGURATION = 'hello-world';
       const SERVICE_NAME = (process.env.K_SERVICE = 'hello-world');
+      const SERVICE_VERSION = (process.env.K_REVISION = 'hello-world.1');
 
       const fakeAuth = {
         async getEnv() {
@@ -609,10 +619,14 @@ describe('metadata', () => {
       };
 
       const sc1 = await metadata.detectServiceContext(fakeAuth);
-      assert.deepStrictEqual(sc1, {service: SERVICE_NAME});
+      assert.deepStrictEqual(sc1, {
+        service: SERVICE_NAME,
+        version: SERVICE_VERSION,
+      });
 
       delete process.env['K_CONFIGURATION'];
       delete process.env['K_SERVICE'];
+      delete process.env['K_REVISION'];
     });
 
     it('should return the correct descriptor for GKE', async () => {


### PR DESCRIPTION
I noticed the detected `serviceContext` was empty for a deployed gen2 Cloud Function.
Turns out the `FUNCTION_NAME` env var is not set anymore.

`K_SERVICE` and `K_REVISION` env vars are recommended to be used for both [Cloud Function](https://cloud.google.com/functions/docs/configuring/env-var#runtime_environment_variables_set_automatically) and [Cloud Run](https://cloud.google.com/run/docs/configuring/services/overview-environment-variables#reserved_environment_variables_for_functions).

Looks like this was missed in https://github.com/googleapis/nodejs-logging/pull/436
