### PR TITLE
fix(logging): Specifying resourceNames should fetch logs only from those resources

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -591,9 +591,9 @@ class Logging {
     }
 
     reqOpts.resourceNames = arrify(reqOpts.resourceNames!);
-    this.projectId = await this.auth.getProjectId();
-    const resourceName = 'projects/' + this.projectId;
-    if (reqOpts.resourceNames.indexOf(resourceName) === -1) {
+    if (reqOpts.resourceNames.length === 0) {
+      this.projectId = await this.auth.getProjectId();
+      const resourceName = 'projects/' + this.projectId;
       reqOpts.resourceNames.push(resourceName);
     }
     delete reqOpts.autoPaginate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,10 +590,11 @@ class Logging {
       reqOpts.filter += ` AND ${timeFilter}`;
     }
 
+    this.projectId = await this.auth.getProjectId();
+    const resourceName = 'projects/' + this.projectId;
     reqOpts.resourceNames = arrify(reqOpts.resourceNames!);
     if (reqOpts.resourceNames.length === 0) {
-      this.projectId = await this.auth.getProjectId();
-      const resourceName = 'projects/' + this.projectId;
+      // If no resource names are provided, default to the current project.
       reqOpts.resourceNames.push(resourceName);
     }
     delete reqOpts.autoPaginate;

--- a/test/index.ts
+++ b/test/index.ts
@@ -389,23 +389,6 @@ describe('Logging', () => {
         await logging.createSink(SINK_NAME, config);
       });
 
-      it('should not add projectId if resourceNames is provided', async () => {
-        const resourceNames = ['projects/other-project/buckets/my-bucket'];
-        const options = {
-          resourceNames: resourceNames,
-        };
-
-        logging.loggingService.listLogEntries = async (
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          reqOpts: any
-        ) => {
-          assert.deepStrictEqual(reqOpts.resourceNames, resourceNames);
-          return [[]];
-        };
-
-        await logging.getEntries(options);
-      });
-
       it('should accept GAX options', async () => {
         const config = {
           a: 'b',
@@ -519,6 +502,23 @@ describe('Logging', () => {
       };
 
       await logging.getEntries();
+    });
+
+    it('should not add projectId if resourceNames is provided', async () => {
+      const resourceNames = ['projects/other-project/buckets/my-bucket'];
+      const options = {
+        resourceNames: resourceNames,
+      };
+
+      logging.loggingService.listLogEntries = async (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        reqOpts: any
+      ) => {
+        assert.deepStrictEqual(reqOpts.resourceNames, resourceNames);
+        return [[]];
+      };
+
+      await logging.getEntries(options);
     });
 
     it('should accept options (and not overwrite timestamp)', async () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -389,6 +389,23 @@ describe('Logging', () => {
         await logging.createSink(SINK_NAME, config);
       });
 
+      it('should not add projectId if resourceNames is provided', async () => {
+        const resourceNames = ['projects/other-project/buckets/my-bucket'];
+        const options = {
+          resourceNames: resourceNames,
+        };
+
+        logging.loggingService.listLogEntries = async (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          reqOpts: any
+        ) => {
+          assert.deepStrictEqual(reqOpts.resourceNames, resourceNames);
+          return [[]];
+        };
+
+        await logging.getEntries(options);
+      });
+
       it('should accept GAX options', async () => {
         const config = {
           a: 'b',


### PR DESCRIPTION

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1593 🦕

This PR addresses an issue where users were unable to fetch logs from a logging bucket located in a different Google Cloud project.

**Issue**
if projects/${BUCKET_CONTAINING_PROJECT}/locations/global/buckets/my-repro-bucket-01/views/_AllLogs has log entry "log-01"
and projects/${BUCKET_CONTAINING_PROJECT}/locations/global/buckets/my-repro-bucket-02/views/_AllLogs has log entry "log-02",
and projects/${BUCKET_CONTAINING_PROJECT}/locations/global/buckets/_Default/views/_AllLogs has log entry "log-01", "log-02", "log-03", "log-04". Then, providing resourceNames: my-repro-bucket-01 and my-repro-bucket-02
should retrieve only "log-01" and "log-02" but in the current library, it returns "log-01", "log-02", "log-03", "log-04"

**Fix**
The fix refines the logic for handling default resource names. The library now checks if the resourceNames array is empty before adding the default project ID.
- If getEntries() is called with no resourceNames, the library adds the current project ID to ensure the API call is valid (preserving the behavior from PR #92).
- If getEntries() is called with a resourceNames array, the library now respects the user's input and does not modify it.

This change ensures that developers can correctly query logs from any bucket they have access to, including those outside of the client's default project. A unit test has been added to verify this behavior and prevent future regressions.